### PR TITLE
Added scroll handler for slash menu

### DIFF
--- a/lib/components/Editor/CustomExtensions/SlashCommands/CommandsList.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/CommandsList.js
@@ -8,6 +8,8 @@ class CommandsList extends React.Component {
     this.state = {
       selectedIndex: 0,
     };
+
+    this.menuRef = React.createRef();
   }
 
   componentDidUpdate(oldProps) {
@@ -16,6 +18,8 @@ class CommandsList extends React.Component {
         selectedIndex: 0,
       });
     }
+
+    this.scrollHandler();
   }
 
   onKeyDown = ({ event }) => {
@@ -64,9 +68,32 @@ class CommandsList extends React.Component {
     }
   };
 
+  scrollHandler = () => {
+    const MARGIN_HEIGHT = 8;
+    const parentItem = this.menuRef.current;
+    const selectedItem = parentItem.children[this.state.selectedIndex];
+    const itemHeight = selectedItem.clientHeight + MARGIN_HEIGHT;
+
+    let scrollPosition = parentItem.scrollTop;
+    if (
+      selectedItem.offsetTop + itemHeight >
+      scrollPosition + parentItem.clientHeight
+    ) {
+      scrollPosition =
+        selectedItem.offsetTop - parentItem.clientHeight + itemHeight;
+    } else if (scrollPosition > selectedItem.offsetTop) {
+      scrollPosition = selectedItem.offsetTop - MARGIN_HEIGHT;
+    }
+
+    this.menuRef.current.scrollTop = scrollPosition;
+  };
+
   render() {
     return (
-      <div className="relative p-3 -mr-1 space-y-2 overflow-x-hidden overflow-y-scroll rounded shadow max-h-80 w-80 editor-command-list--root">
+      <div
+        ref={this.menuRef}
+        className="relative p-3 -mr-1 space-y-2 overflow-x-hidden overflow-y-scroll rounded shadow max-h-80 w-80 editor-command-list--root"
+      >
         {this.props.items.map((item, index) => (
           <Item
             key={item.title}


### PR DESCRIPTION
Fixes #81
- Added a scroll handler for the slash menu to automatically scroll on keyboard navigation.
![Scroll handler for slash menu](https://user-images.githubusercontent.com/35297280/145165468-922d3756-98a2-4763-8ace-d72c8ed5060a.gif)
@amaldinesh7 _a please have a look.