### PR TITLE
Fixed focus issue in fixed menu

### DIFF
--- a/lib/components/Common/Dropdown/index.js
+++ b/lib/components/Common/Dropdown/index.js
@@ -40,7 +40,7 @@ const Dropdown = forwardRef(
     ref
   ) => {
     const wrapperRef = useRef();
-    const Target = customTarget;
+    const Target = customTarget();
     const isControlled = !(isOpen === undefined || isOpen === null);
 
     const [visible, setVisibility] = useState(false);
@@ -101,7 +101,7 @@ const Dropdown = forwardRef(
             onClick={handleButtonClick}
             className="h-full"
           >
-            <Target />
+            {Target}
           </div>
         ) : (
           <div>

--- a/lib/components/Editor/CustomExtensions/FixedMenu/FontSizeOption.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/FontSizeOption.js
@@ -14,7 +14,6 @@ const FontSizeOption = ({ editor }) => {
     { label: "H1", value: 1 },
     { label: "H2", value: 2 },
     { label: "H3", value: 3 },
-    { label: "H4", value: 4 },
   ];
 
   const isActive = (level) => editor.isActive("heading", { level });

--- a/lib/components/Editor/CustomExtensions/FixedMenu/LinkOption.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/LinkOption.js
@@ -60,6 +60,7 @@ const LinkOption = ({ editor }) => {
       <div className="flex py-1 space-x-3 add-link-form">
         <div className="flex-row w-full">
           <Input
+            autoFocus
             name="url"
             value={urlString}
             placeholder="Paste URL"

--- a/lib/styles/components/_dropdown.scss
+++ b/lib/styles/components/_dropdown.scss
@@ -8,7 +8,6 @@
 
 .neeto-ui-dropdown__popup {
   width: auto;
-  min-width: 168px;
   max-height: 360px;
   overflow-y: auto;
   background-color: $neeto-ui-white;


### PR DESCRIPTION
Fixes #91 
- Fixed focus issue of dropdown buttons in `FixedMenu`.
- Added autofocus to the `input` of link dropdown.
- Removed `h4` option from font size dropdown.

![Fixed focus issue](https://user-images.githubusercontent.com/35297280/145577100-ff3f994a-597e-4df0-83ac-94a98ae6b3be.gif)

@amaldinesh7 _a please have a look.

