### PR TITLE
Add markdown editor

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -230,8 +230,15 @@ const App = () => {
       </div>
       <Heading type="sub">Support for an optional markdown mode</Heading>
       <Description></Description>
+      <Heading type="sub">Support for markdown mode</Heading>
+      <Description>
+        Neeto Editor comes with a markdown mode where users can type the content
+        in markdown, which gets converted to the default rich text and vice
+        versa. This can be achieved by providing a truthy value to the
+        `markdownMode` prop.
+      </Description>
       <div className="flex">
-        <CodeBlock></CodeBlock>
+        <CodeBlock>{STRINGS.markdownModeSampleCode}</CodeBlock>
         <SampleEditor markdownMode />
       </div>
     </div>

--- a/example/App.js
+++ b/example/App.js
@@ -228,6 +228,12 @@ const App = () => {
         <CodeBlock>{STRINGS.addonsSampleCode}</CodeBlock>
         <SampleEditor addons={SAMPLE_ADDONS} />
       </div>
+      <Heading type="sub">Support for an optional markdown mode</Heading>
+      <Description></Description>
+      <div className="flex">
+        <CodeBlock></CodeBlock>
+        <SampleEditor markdownMode />
+      </div>
     </div>
   );
 };

--- a/example/App.js
+++ b/example/App.js
@@ -228,8 +228,6 @@ const App = () => {
         <CodeBlock>{STRINGS.addonsSampleCode}</CodeBlock>
         <SampleEditor addons={SAMPLE_ADDONS} />
       </div>
-      <Heading type="sub">Support for an optional markdown mode</Heading>
-      <Description></Description>
       <Heading type="sub">Support for markdown mode</Heading>
       <Description>
         Neeto Editor comes with a markdown mode where users can type the content

--- a/example/constants.js
+++ b/example/constants.js
@@ -126,6 +126,11 @@ export const EDITOR_PROP_TABLE_ROWS = [
     "Accepts an array of strings, each corresponding to the name of an addon.",
     `["highlight", "emoji", "code-block", "block-quote", "image-upload"]`,
   ],
+  [
+    "markdownMode",
+    "Accepts a boolean value. When true, a markdown editor will be made available in addition to rich text editor.",
+    "true",
+  ],
 ];
 
 export const EDITOR_CONTENT_PROP_TABLE_ROWS = [

--- a/example/constants.js
+++ b/example/constants.js
@@ -222,6 +222,9 @@ export const STRINGS = {
     "image-upload",
   ];
 
-  <Editor addons={addons} />
+  <Editor addons={addons} />`,
+
+  markdownModeSampleCode: `
+  <Editor markdownMode />
   `,
 };

--- a/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
@@ -3,7 +3,7 @@ import Tab from "components/Common/Tab";
 
 const MarkdownTabSwitcher = ({ isMarkdownTab, setIsMarkdownTab }) => {
   return (
-    <div className="flex">
+    <div className="neeto-editor-markdown-tabswitcher">
       <Tab>
         <Tab.Item
           active={!isMarkdownTab}

--- a/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Tab from "../../../Common/Tab";
+import Tab from "components/Common/Tab";
 
 const MarkdownTabSwitcher = ({ isMarkdownTab, setIsMarkdownTab }) => {
   return (

--- a/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
@@ -1,15 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
 import Tab from "../../../Common/Tab";
 
-const TabSwitcher = () => {
-  const [active, setActive] = useState(true);
+const MarkdownTabSwitcher = ({ isMarkdownTab, setIsMarkdownTab }) => {
   return (
-    <div className="inline-block float-right">
+    <div className="flex">
       <Tab>
-        <Tab.Item active={active} onClick={() => setActive(true)}>
+        <Tab.Item
+          active={!isMarkdownTab}
+          onClick={() => setIsMarkdownTab(false)}
+        >
           Rich Text
         </Tab.Item>
-        <Tab.Item active={!active} onClick={() => setActive(false)}>
+        <Tab.Item active={isMarkdownTab} onClick={() => setIsMarkdownTab(true)}>
           Markdown
         </Tab.Item>
       </Tab>
@@ -17,4 +19,4 @@ const TabSwitcher = () => {
   );
 };
 
-export default TabSwitcher;
+export default MarkdownTabSwitcher;

--- a/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
@@ -1,0 +1,20 @@
+import React, { useState } from "react";
+import Tab from "../../../Common/Tab";
+
+const TabSwitcher = () => {
+  const [active, setActive] = useState(true);
+  return (
+    <div className="inline-block float-right">
+      <Tab>
+        <Tab.Item active={active} onClick={() => setActive(true)}>
+          Rich Text
+        </Tab.Item>
+        <Tab.Item active={!active} onClick={() => setActive(false)}>
+          Markdown
+        </Tab.Item>
+      </Tab>
+    </div>
+  );
+};
+
+export default TabSwitcher;

--- a/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/TabSwitcher.js
@@ -1,17 +1,23 @@
 import React from "react";
 import Tab from "components/Common/Tab";
 
-const MarkdownTabSwitcher = ({ isMarkdownTab, setIsMarkdownTab }) => {
+const MarkdownTabSwitcher = ({
+  isMarkdownTabActive,
+  setIsMarkdownTabActive,
+}) => {
   return (
     <div className="neeto-editor-markdown-tabswitcher">
       <Tab>
         <Tab.Item
-          active={!isMarkdownTab}
-          onClick={() => setIsMarkdownTab(false)}
+          active={!isMarkdownTabActive}
+          onClick={() => setIsMarkdownTabActive(false)}
         >
           Rich Text
         </Tab.Item>
-        <Tab.Item active={isMarkdownTab} onClick={() => setIsMarkdownTab(true)}>
+        <Tab.Item
+          active={isMarkdownTabActive}
+          onClick={() => setIsMarkdownTabActive(true)}
+        >
           Markdown
         </Tab.Item>
       </Tab>

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef, useState } from "react";
+import classNames from "classnames";
+
+import { HTMLToMarkDown, markdownToHTML } from "utils/markdown";
+
+const MarkdownEditor = ({ editor, className, ...otherProps }) => {
+  const markdownData = HTMLToMarkDown(editor.getHTML());
+
+  const [content, setContent] = useState(markdownData);
+  const editorContentRef = useRef();
+
+  useEffect(() => {
+    editorContentRef.current = content;
+  }, [content]);
+
+  useEffect(() => {
+    editorContentRef.current = content;
+    return () =>
+      editor.commands.setContent(markdownToHTML(editorContentRef.current));
+  }, []);
+
+  return (
+    <div
+      contentEditable
+      suppressContentEditableWarning
+      onInput={(e) => setContent(e.target.textContent)}
+      className={classNames(
+        "ProseMirror focus:outline-none whitespace-pre-wrap p-3",
+        { [className]: className }
+      )}
+      {...otherProps}
+    >
+      {markdownData}
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 
-import { HTMLToMarkDown, markdownToHTML } from "utils/markdown";
+import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
 
 const MarkdownEditor = ({ editor, className, ...otherProps }) => {
-  const markdownData = HTMLToMarkDown(editor.getHTML());
+  const markdownData = htmlToMarkdown(editor.getHTML());
 
   const [content, setContent] = useState(markdownData);
   const editorContentRef = useRef();
@@ -16,7 +16,7 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
   useEffect(() => {
     editorContentRef.current = content;
     return () =>
-      editor.commands.setContent(markdownToHTML(editorContentRef.current));
+      editor.commands.setContent(markdownToHtml(editorContentRef.current));
   }, []);
 
   return (

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -33,10 +33,9 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
       value={content}
       spellCheck={false}
       onChange={handleChange}
-      className={classNames(
-        "ProseMirror focus:outline-none whitespace-pre-wrap p-3 w-full resize-none",
-        { [className]: className }
-      )}
+      className={classNames("ProseMirror neeto-editor-markdown", {
+        [className]: className,
+      })}
       {...otherProps}
     />
   );

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -4,34 +4,33 @@ import classNames from "classnames";
 import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
 
 const MarkdownEditor = ({ editor, className, ...otherProps }) => {
-  const markdownData = htmlToMarkdown(editor.getHTML());
-
-  const [content, setContent] = useState(markdownData);
-  const editorContentRef = useRef();
+  const [content, setContent] = useState(() =>
+    htmlToMarkdown(editor.getHTML())
+  );
+  const contentRef = useRef(content);
 
   useEffect(() => {
-    editorContentRef.current = content;
+    contentRef.current = content;
   }, [content]);
 
   useEffect(() => {
-    editorContentRef.current = content;
-    return () =>
-      editor.commands.setContent(markdownToHtml(editorContentRef.current));
+    return () => editor.commands.setContent(markdownToHtml(contentRef.current));
   }, []);
 
+  const handleChange = (e) => {
+    setContent(e.target.value);
+  };
+
   return (
-    <div
-      contentEditable
-      suppressContentEditableWarning
-      onInput={(e) => setContent(e.target.textContent)}
+    <textarea
+      value={content}
+      onChange={handleChange}
       className={classNames(
-        "ProseMirror focus:outline-none whitespace-pre-wrap p-3",
+        "ProseMirror focus:outline-none whitespace-pre-wrap p-3 w-full resize-none",
         { [className]: className }
       )}
       {...otherProps}
-    >
-      {markdownData}
-    </div>
+    />
   );
 };
 

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -31,6 +31,7 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
     <textarea
       ref={textareaRef}
       value={content}
+      spellCheck={false}
       onChange={handleChange}
       className={classNames(
         "ProseMirror focus:outline-none whitespace-pre-wrap p-3 w-full resize-none",

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -7,10 +7,16 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
   const [content, setContent] = useState(() =>
     htmlToMarkdown(editor.getHTML())
   );
+
+  const textareaRef = useRef();
   const contentRef = useRef(content);
 
   useEffect(() => {
     contentRef.current = content;
+
+    const PADDING_HEIGHT = 12;
+    textareaRef.current.style.height =
+      textareaRef.current.scrollHeight + PADDING_HEIGHT * 2 + "px";
   }, [content]);
 
   useEffect(() => {
@@ -23,6 +29,7 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
 
   return (
     <textarea
+      ref={textareaRef}
       value={content}
       onChange={handleChange}
       className={classNames(

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import classNames from "classnames";
 
 import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
@@ -13,15 +13,19 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
 
   useEffect(() => {
     contentRef.current = content;
-
-    const PADDING_HEIGHT = 12;
-    textareaRef.current.style.height =
-      textareaRef.current.scrollHeight + PADDING_HEIGHT * 2 + "px";
   }, [content]);
 
   useEffect(() => {
     return () => editor.commands.setContent(markdownToHtml(contentRef.current));
   }, []);
+
+  useLayoutEffect(() => {
+    const BORDER_HEIGHT = 1;
+
+    textareaRef.current.style.height = "inherit";
+    textareaRef.current.style.height =
+      textareaRef.current.scrollHeight + 2 * BORDER_HEIGHT + "px";
+  }, [content]);
 
   const handleChange = (e) => {
     setContent(e.target.value);

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -31,7 +31,6 @@ const MarkdownEditor = ({ editor, className, ...otherProps }) => {
     <textarea
       ref={textareaRef}
       value={content}
-      spellCheck={false}
       onChange={handleChange}
       className={classNames("ProseMirror neeto-editor-markdown", {
         [className]: className,

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -5,6 +5,7 @@ import { useEditor, EditorContent } from "@tiptap/react";
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
 import ImageUploader from "./CustomExtensions/Image/Uploader";
+import MarkdownTabSwitcher from "./CustomExtensions/Markdown/TabSwitcher";
 import useCustomExtensions from "./CustomExtensions/useCustomExtensions";
 
 const Tiptap = (
@@ -13,6 +14,7 @@ const Tiptap = (
     titleError = false,
     hideSlashCommands = false,
     addons = [],
+    markdownMode = false,
     className,
     uploadEndpoint,
     initialValue = "",
@@ -119,6 +121,7 @@ const Tiptap = (
         imageUploadUrl={uploadEndpoint}
       />
       <EditorContent editor={editor} {...otherProps} />
+      {markdownMode && <MarkdownTabSwitcher />}
     </div>
   );
 };

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -113,7 +113,7 @@ const Tiptap = (
           setIsMarkdownTab={setIsMarkdownTab}
         />
       )}
-      {isFixedMenuActive && (
+      {isFixedMenuActive && !isMarkdownTab && (
         <FixedMenu
           editor={editor}
           variables={variables}

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -5,6 +5,7 @@ import { useEditor, EditorContent } from "@tiptap/react";
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
 import ImageUploader from "./CustomExtensions/Image/Uploader";
+import MarkdownEditor from "./CustomExtensions/Markdown";
 import MarkdownTabSwitcher from "./CustomExtensions/Markdown/TabSwitcher";
 import useCustomExtensions from "./CustomExtensions/useCustomExtensions";
 
@@ -31,6 +32,7 @@ const Tiptap = (
   ref
 ) => {
   const [isImageUploadVisible, setImageUploadVisible] = useState(false);
+  const [isMarkdownTab, setIsMarkdownTab] = useState(false);
 
   let isPlaceholderActive = false;
   if (placeholder) {
@@ -76,21 +78,23 @@ const Tiptap = (
     options: allOptions,
   });
 
+  const editorClasses = classNames(
+    "focus:outline-none whitespace-pre-wrap p-3",
+    {
+      "slash-active": showSlashCommandPlaceholder,
+      "fixed-menu-active border": isFixedMenuActive,
+      "bubble-menu-active": isBubbleMenuActive,
+      [className]: className,
+    }
+  );
+
   const editor = useEditor({
     extensions: customExtensions,
     content: initialValue,
     injectCSS: false,
     editorProps: {
       attributes: {
-        class: classNames("neeto-editor", {
-          "slash-active": showSlashCommandPlaceholder,
-          "fixed-menu-active": isFixedMenuActive,
-          "bubble-menu-active": isBubbleMenuActive,
-          "force-title": forceTitle,
-          "force-title--error": titleError,
-          "placeholder-active": isPlaceholderActive,
-          [className]: className,
-        }),
+        class: editorClasses,
       },
     },
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
@@ -103,6 +107,12 @@ const Tiptap = (
 
   return (
     <div className="neeto-editor-wrapper">
+      {markdownMode && (
+        <MarkdownTabSwitcher
+          isMarkdownTab={isMarkdownTab}
+          setIsMarkdownTab={setIsMarkdownTab}
+        />
+      )}
       {isFixedMenuActive && (
         <FixedMenu
           editor={editor}
@@ -120,8 +130,15 @@ const Tiptap = (
         editor={editor}
         imageUploadUrl={uploadEndpoint}
       />
-      <EditorContent editor={editor} {...otherProps} />
-      {markdownMode && <MarkdownTabSwitcher />}
+      {isMarkdownTab ? (
+        <MarkdownEditor
+          editor={editor}
+          className={editorClasses}
+          {...otherProps}
+        />
+      ) : (
+        <EditorContent editor={editor} {...otherProps} />
+      )}
     </div>
   );
 };

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -32,7 +32,7 @@ const Tiptap = (
   ref
 ) => {
   const [isImageUploadVisible, setImageUploadVisible] = useState(false);
-  const [isMarkdownTab, setIsMarkdownTab] = useState(false);
+  const [isMarkdownTabActive, setIsMarkdownTabActive] = useState(false);
 
   let isPlaceholderActive = false;
   if (placeholder) {
@@ -106,11 +106,11 @@ const Tiptap = (
     <div className="neeto-editor-wrapper">
       {markdownMode && (
         <MarkdownTabSwitcher
-          isMarkdownTab={isMarkdownTab}
-          setIsMarkdownTab={setIsMarkdownTab}
+          isMarkdownTabActive={isMarkdownTabActive}
+          setIsMarkdownTabActive={setIsMarkdownTabActive}
         />
       )}
-      {isFixedMenuActive && !isMarkdownTab && (
+      {isFixedMenuActive && !isMarkdownTabActive && (
         <FixedMenu
           editor={editor}
           variables={variables}
@@ -127,7 +127,7 @@ const Tiptap = (
         editor={editor}
         imageUploadUrl={uploadEndpoint}
       />
-      {isMarkdownTab ? (
+      {isMarkdownTabActive ? (
         <MarkdownEditor
           editor={editor}
           className={editorClasses}

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -78,15 +78,12 @@ const Tiptap = (
     options: allOptions,
   });
 
-  const editorClasses = classNames(
-    "focus:outline-none whitespace-pre-wrap p-3",
-    {
-      "slash-active": showSlashCommandPlaceholder,
-      "fixed-menu-active border": isFixedMenuActive,
-      "bubble-menu-active": isBubbleMenuActive,
-      [className]: className,
-    }
-  );
+  const editorClasses = classNames("neeto-editor", {
+    "slash-active": showSlashCommandPlaceholder,
+    "fixed-menu-active border": isFixedMenuActive,
+    "bubble-menu-active": isBubbleMenuActive,
+    [className]: className,
+  });
 
   const editor = useEditor({
     extensions: customExtensions,

--- a/lib/index.scss
+++ b/lib/index.scss
@@ -16,6 +16,7 @@
 @import "./styles/editor/menu";
 @import "./styles/editor/image-uploader";
 @import "./styles/editor/emoji";
+@import "./styles/editor/markdown";
 
 body {
   margin: 0;

--- a/lib/styles/editor/_markdown.scss
+++ b/lib/styles/editor/_markdown.scss
@@ -1,0 +1,8 @@
+.neeto-editor-markdown {
+  width: 100%;
+  resize: none;
+}
+
+.neeto-editor-markdown-tabswitcher {
+  display: flex;
+}

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -3,6 +3,9 @@ import { marked } from "marked";
 import TurndownService from "turndown";
 
 export const markdownToHtml = (data) => {
+  // Convert \ to empty <p> tag (blank line)
+  data = data.replaceAll(/^\\$/gm, "<p></p>");
+
   let parsedHTML = marked.parse(data);
 
   // Remove <p> tag just outside <img> tag
@@ -23,6 +26,7 @@ export const htmlToMarkdown = (data) => {
   const turndownService = new TurndownService({
     headingStyle: "atx",
     codeBlockStyle: "fenced",
+    blankReplacement: (_content, node) => (node.isBlock ? "\\\n" : ""),
   });
 
   // Strike through rule: ~strike~

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -5,13 +5,16 @@ import TurndownService from "turndown";
 export const markdownToHtml = (data) => {
   let parsedHTML = marked.parse(data);
 
-  // Strip off <p> tags from <img> tags.
+  // Remove <p> tag just outside <img> tag
   parsedHTML = parsedHTML.replace(/<p><img[^>]*><\/p>/g, (match) =>
     match.replace(/<\/?p>/g, "")
   );
 
-  // Convert ==text== to <mark>text</mark>
+  // Highlight rule: ==text== => <mark>text</mark>
   parsedHTML = parsedHTML.replaceAll(/==([^=]+)==/g, "<mark>$1</mark>");
+
+  // Convert --text-- to <u>text</u>
+  parsedHTML = parsedHTML.replaceAll(/--([^-]+)--/g, "<u>$1</u>");
 
   return parsedHTML;
 };
@@ -22,16 +25,22 @@ export const htmlToMarkdown = (data) => {
     codeBlockStyle: "fenced",
   });
 
-  // Adding strike through rule: ~strike~
+  // Strike through rule: ~strike~
   turndownService.addRule("strikethrough", {
     filter: ["del", "s", "strike"],
     replacement: (content) => `~${content}~`,
   });
 
-  // Adding highlight rule: ==text==
+  // Highlight rule: <mark>text</mark> => ==text==
   turndownService.addRule("highlight", {
     filter: ["mark"],
     replacement: (content) => `==${content}==`,
+  });
+
+  // Underline rule: <u>text</u> => --text--
+  turndownService.addRule("underline", {
+    filter: ["u"],
+    replacement: (content) => `--${content}--`,
   });
 
   return DOMPurify.sanitize(turndownService.turndown(data));

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -1,7 +1,35 @@
-export const markdownToHTML = (data) => {
-  return `${data} in markdown`;
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+import TurndownService from "turndown";
+
+export const markdownToHtml = (data) => {
+  const parsedHTML = marked.parse(data);
+
+  // Strip off <p> tags from images.
+  const result = parsedHTML
+    .replaceAll(/<p>(?=<img)/g, "")
+    .replaceAll(/(?<=<img[^>]*\/>)<\/p>/g, "");
+
+  return result;
 };
 
-export const HTMLToMarkDown = (data) => {
-  return `${data} in html`;
+export const htmlToMarkdown = (data) => {
+  const turndownService = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
+
+  // Adding strike through rule: ~strike~
+  turndownService.addRule("strikethrough", {
+    filter: ["del", "s", "strike"],
+    replacement: (content) => `~${content}~`,
+  });
+
+  // Adding highlight rule: ==text==
+  turndownService.addRule("highlight", {
+    filter: ["mark"],
+    replacement: (content) => `==${content}==`,
+  });
+
+  return DOMPurify.sanitize(turndownService.turndown(data));
 };

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -3,14 +3,17 @@ import { marked } from "marked";
 import TurndownService from "turndown";
 
 export const markdownToHtml = (data) => {
-  const parsedHTML = marked.parse(data);
+  let parsedHTML = marked.parse(data);
 
-  // Strip off <p> tags from images.
-  const result = parsedHTML
-    .replaceAll(/<p>(?=<img)/g, "")
-    .replaceAll(/(?<=<img[^>]*\/>)<\/p>/g, "");
+  // Strip off <p> tags from <img> tags.
+  parsedHTML = parsedHTML.replace(/<p><img[^>]*><\/p>/g, (match) =>
+    match.replace(/<\/?p>/g, "")
+  );
 
-  return result;
+  // Convert ==text== to <mark>text</mark>
+  parsedHTML = parsedHTML.replaceAll(/==([^=]+)==/g, "<mark>$1</mark>");
+
+  return parsedHTML;
 };
 
 export const htmlToMarkdown = (data) => {

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -16,7 +16,7 @@ export const markdownToHtml = (data) => {
   // Convert --text-- to <u>text</u>
   parsedHTML = parsedHTML.replaceAll(/--([^-]+)--/g, "<u>$1</u>");
 
-  return parsedHTML;
+  return DOMPurify.sanitize(parsedHTML);
 };
 
 export const htmlToMarkdown = (data) => {
@@ -43,5 +43,5 @@ export const htmlToMarkdown = (data) => {
     replacement: (content) => `--${content}--`,
   });
 
-  return DOMPurify.sanitize(turndownService.turndown(data));
+  return turndownService.turndown(data);
 };

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -1,0 +1,7 @@
+export const markdownToHTML = (data) => {
+  return `${data} in markdown`;
+};
+
+export const HTMLToMarkDown = (data) => {
+  return `${data} in html`;
+};

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "lodash.isempty": "^4.4.0",
     "lodash.isplainobject": "^4.0.6",
     "lowlight": "^1.20.0",
+    "marked": "^4.0.7",
     "peer-deps-externals-webpack-plugin": "1.0.4",
     "react-hotkeys-hook": "^3.4.4",
     "react-icons": "^4.2.0",
     "react-popper": "^2.2.5",
     "react-router-dom": "^6.0.2",
-    "tippy.js": "^6.3.1"
+    "tippy.js": "^6.3.1",
+    "turndown": "^7.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4790,6 +4790,11 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
+domino@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
+  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
+
 dompurify@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
@@ -7925,6 +7930,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.7.tgz#596a0826e7a8c6b4119eacd00b0220ddaee7fc71"
+  integrity sha512-mQrRvV2vRk7DHZsWsYJfAjmBo+lSYPhTJPThaaGpkEfmC+4oefeug2txZniQTieDS0CFpokfVhd7JuS5GtnHhA==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -11801,6 +11811,13 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+turndown@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"
+  integrity sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==
+  dependencies:
+    domino "^2.1.6"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Fixes #28 
- Added markdown editor.
- Updated documentation.
- Uses [marked](https://www.npmjs.com/package/marked) package for markdown to HTML conversion.
- Uses [turndown](https://www.npmjs.com/package/turndown) package for HTML to markdown conversion.

Please go through this video: https://vimeo.com/656211314/5713fc4066

@amaldinesh7 _a please have a look.