### PR TITLE
Fixed UI issues of neetoEditor on a neetoUI Pane

### DIFF
--- a/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
@@ -74,7 +74,7 @@ export default function index({ editor, formatterOptions }) {
       tippyOptions={{
         arrow: roundArrow,
         placement: "top-start",
-        zIndex: 99998,
+        zIndex: 99999,
       }}
       className="relative flex overflow-hidden rounded shadow editor-command-list--root"
     >

--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiPicker/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiPicker/ExtensionConfig.js
@@ -47,6 +47,7 @@ const EmojiPicker = Node.create({
                 interactive: true,
                 trigger: "manual",
                 placement: "bottom-start",
+                zIndex: 99999,
               });
             },
 

--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/ExtensionConfig.js
@@ -47,6 +47,7 @@ const EmojiSuggestion = Node.create({
                 interactive: true,
                 trigger: "manual",
                 placement: "top-start",
+                zIndex: 99999,
               });
             },
 

--- a/lib/components/Editor/CustomExtensions/Mention/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Mention/ExtensionConfig.js
@@ -26,6 +26,7 @@ const suggestion = {
           interactive: true,
           trigger: "manual",
           placement: "bottom-start",
+          zIndex: 99999,
         });
       },
 

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -203,6 +203,7 @@ export default {
                     trigger: "manual",
                     placement: "bottom-start",
                     arrow: false,
+                    zIndex: 99999,
                   });
                 },
                 onUpdate(props) {

--- a/lib/components/Editor/CustomExtensions/Variable/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Variable/ExtensionConfig.js
@@ -181,6 +181,7 @@ const suggestionConfig = {
           interactive: true,
           trigger: "manual",
           placement: "bottom-start",
+          zIndex: 99999,
         });
       },
       onUpdate(props) {

--- a/lib/styles/components/_button.scss
+++ b/lib/styles/components/_button.scss
@@ -6,7 +6,6 @@
   border-radius: $neeto-ui-rounded-sm;
   line-height: 1.2;
   transition: $neeto-ui-transition;
-  position: relative;
   border: none;
   cursor: pointer;
   padding: 0;


### PR DESCRIPTION
Fixes #99
- Increased z-index of suggestion popups to appear above neetoUI `Pane` component: mentions, emoji suggestion, emoji picker, variables, slash commands, and bubble menu.
- Removed `position: relative` from neetoUI button component.