### PR TITLE
Added addons prop to customize the available options in menu

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -17,6 +17,8 @@ import {
   STRINGS,
   EDITOR_CONTENT_PROP_TABLE_ROWS,
   SAMPLE_ADDONS,
+  EDITOR_ADDONS_TABLE_ROWS,
+  EDITOR_ADDONS_TABLE_COLUMNS,
 } from "./constants";
 import Table from "./components/Table";
 
@@ -214,14 +216,15 @@ const App = () => {
         <HighlightText>bulleted list</HighlightText> and{" "}
         <HighlightText>numbered list</HighlightText> by default. Additional
         options can be enabled by passing an array of strings to the{" "}
-        <HighlightText>addons</HighlightText> prop. The list of available addons
-        is <HighlightText>hightlight</HighlightText>,{" "}
-        <HighlightText>emoji</HighlightText>,{" "}
-        <HighlightText>code-block</HighlightText>,{" "}
-        <HighlightText>block-quote</HighlightText>, and{" "}
-        <HighlightText>image-upload</HighlightText>.
+        <HighlightText>addons</HighlightText> prop.
       </Description>
-      <div className="flex">
+      <h3 className="mt-4 mb-2 font-bold">Available addons</h3>
+      <Table
+        columns={EDITOR_ADDONS_TABLE_COLUMNS}
+        rows={EDITOR_ADDONS_TABLE_ROWS}
+        className="prop-detail-table"
+      />
+      <div className="flex mt-4">
         <CodeBlock>{STRINGS.addonsSampleCode}</CodeBlock>
         <SampleEditor addons={SAMPLE_ADDONS} />
       </div>

--- a/example/App.js
+++ b/example/App.js
@@ -200,6 +200,38 @@ const App = () => {
           forceTitle
         />
       </div>
+      <Heading type="sub">Support for addons</Heading>
+      <Description>
+        Neeto editor enables the options{" "}
+        <HighlightText>font size</HighlightText>,{" "}
+        <HighlightText>font color</HighlightText>,{" "}
+        <HighlightText>bold</HighlightText>,{" "}
+        <HighlightText>italics</HighlightText>,{" "}
+        <HighlightText>underline</HighlightText>,{" "}
+        <HighlightText>strike through</HighlightText>,{" "}
+        <HighlightText>link</HighlightText>,{" "}
+        <HighlightText>bulleted list</HighlightText> and{" "}
+        <HighlightText>numbered list</HighlightText> by default. Additional
+        options can be enabled by passing an array of strings to the{" "}
+        <HighlightText>addons</HighlightText> prop. The list of available addons
+        is <HighlightText>hightlight</HighlightText>,{" "}
+        <HighlightText>emoji</HighlightText>,{" "}
+        <HighlightText>code-block</HighlightText>,{" "}
+        <HighlightText>block-quote</HighlightText>, and{" "}
+        <HighlightText>image-upload</HighlightText>.
+      </Description>
+      <div className="flex">
+        <CodeBlock>{STRINGS.addonsSampleCode}</CodeBlock>
+        <SampleEditor
+          addons={[
+            "highlight",
+            "emoji",
+            "code-block",
+            "block-quote",
+            "image-upload",
+          ]}
+        />
+      </div>
     </div>
   );
 };

--- a/example/App.js
+++ b/example/App.js
@@ -16,6 +16,7 @@ import {
   SAMPLE_VARIABLES,
   STRINGS,
   EDITOR_CONTENT_PROP_TABLE_ROWS,
+  SAMPLE_ADDONS,
 } from "./constants";
 import Table from "./components/Table";
 
@@ -222,15 +223,7 @@ const App = () => {
       </Description>
       <div className="flex">
         <CodeBlock>{STRINGS.addonsSampleCode}</CodeBlock>
-        <SampleEditor
-          addons={[
-            "highlight",
-            "emoji",
-            "code-block",
-            "block-quote",
-            "image-upload",
-          ]}
-        />
+        <SampleEditor addons={SAMPLE_ADDONS} />
       </div>
     </div>
   );

--- a/example/constants.js
+++ b/example/constants.js
@@ -149,6 +149,16 @@ export const SAMPLE_ADDONS = [
   "image-upload",
 ];
 
+export const EDITOR_ADDONS_TABLE_COLUMNS = ["Prop", "Description"];
+
+export const EDITOR_ADDONS_TABLE_ROWS = [
+  ["highlight", "Emphasize important texts by marking it with a color."],
+  ["emoji", "Add emojis to your content using an emoji picker."],
+  ["code-block", "Provide syntax highlighting for code snippets."],
+  ["block-quote", "Highlight a block of text as a quote."],
+  ["image-upload", "Upload images to the editor."],
+];
+
 export const STRINGS = {
   fixedMenuSampleCode: `
   <Editor />`,

--- a/example/constants.js
+++ b/example/constants.js
@@ -121,6 +121,11 @@ export const EDITOR_PROP_TABLE_ROWS = [
     "Accepts a string value. Can be used for further customisation of the editor content layout.",
     `"neeto-editor-content"`,
   ],
+  [
+    "addons",
+    "Accepts an array of strings, each corresponding to the name of an addon.",
+    `["highlight", "emoji", "code-block", "block-quote", "image-upload"]`,
+  ],
 ];
 
 export const EDITOR_CONTENT_PROP_TABLE_ROWS = [
@@ -172,7 +177,7 @@ export const STRINGS = {
 
   mentionsSampleCode: `
   const mentions = [
-    { 
+    {
       label: "Oliver Smith",
       key: "oliver-smith",
       imageUrl: "https://i.pravatar.cc/300"
@@ -187,6 +192,17 @@ export const STRINGS = {
 
   forceTitleSampleCode: `
   const placeholder = { title: 'Input title here', paragraph: 'Enter your content' };
- 
+
   <Editor placeholder={placeholder} forceTitle />`,
+
+  addonsSampleCode: `
+  <Editor
+    addons={[
+      "highlight",
+      "emoji",
+      "code-block",
+      "block-quote",
+      "image-upload",
+    ]}
+  />`,
 };

--- a/example/constants.js
+++ b/example/constants.js
@@ -141,6 +141,14 @@ export const EDITOR_CONTENT_PROP_TABLE_ROWS = [
   ],
 ];
 
+export const SAMPLE_ADDONS = [
+  "highlight",
+  "emoji",
+  "code-block",
+  "block-quote",
+  "image-upload",
+];
+
 export const STRINGS = {
   fixedMenuSampleCode: `
   <Editor />`,
@@ -196,13 +204,14 @@ export const STRINGS = {
   <Editor placeholder={placeholder} forceTitle />`,
 
   addonsSampleCode: `
-  <Editor
-    addons={[
-      "highlight",
-      "emoji",
-      "code-block",
-      "block-quote",
-      "image-upload",
-    ]}
-  />`,
+  const addons = [
+    "highlight",
+    "emoji",
+    "code-block",
+    "block-quote",
+    "image-upload",
+  ];
+
+  <Editor addons={addons} />
+  `,
 };

--- a/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
@@ -13,11 +13,11 @@ import {
 import { roundArrow } from "tippy.js";
 import "tippy.js/dist/svg-arrow.css";
 
-export default function index({ editor, formatterOptions }) {
+export default function index({ editor, options }) {
   if (!editor) {
     return null;
   }
-  const options = [
+  const availableOptions = [
     {
       Icon: TextBold,
       command: () => editor.chain().focus().toggleBold().run(),
@@ -59,7 +59,7 @@ export default function index({ editor, formatterOptions }) {
       Icon: Code,
       command: () => editor.chain().focus().toggleCode().run(),
       active: editor.isActive("code"),
-      optionName: "code",
+      optionName: "code-block",
     },
     {
       Icon: Highlight,
@@ -78,8 +78,8 @@ export default function index({ editor, formatterOptions }) {
       }}
       className="neeto-editor-bubble-menu"
     >
-      {options
-        .filter(({ optionName }) => formatterOptions.includes(optionName))
+      {availableOptions
+        .filter(({ optionName }) => options.includes(optionName))
         .map((option) => (
           <Option {...option} key={option.optionName} />
         ))}
@@ -89,12 +89,9 @@ export default function index({ editor, formatterOptions }) {
 
 const Option = ({ Icon, command, active, iconSize }) => (
   <div
-    className={classnames(
-      "neeto-editor-bubble-menu__item",
-      {
-        "active": active,
-      }
-    )}
+    className={classnames("neeto-editor-bubble-menu__item", {
+      active: active,
+    })}
     onClick={command}
   >
     <Icon size={iconSize || 20} />

--- a/lib/components/Editor/CustomExtensions/FixedMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/index.js
@@ -10,8 +10,6 @@ import {
   ListNumber,
   Image,
   Quote,
-  Undo,
-  Redo,
 } from "@bigbinary/neeto-icons";
 
 import TextColorOption from "./TextColorOption";
@@ -20,7 +18,11 @@ import Variables from "../Variable";
 import LinkOption from "./LinkOption";
 import EmojiOption from "./EmojiOption";
 
-import { MENU_ICON_SIZE, ICON_COLOR_ACTIVE, ICON_COLOR_INACTIVE } from "./constants";
+import {
+  MENU_ICON_SIZE,
+  ICON_COLOR_ACTIVE,
+  ICON_COLOR_INACTIVE,
+} from "./constants";
 
 const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
   if (!editor) {
@@ -95,23 +97,6 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
     },
   ];
 
-  const editorOptions = [
-    {
-      Icon: Undo,
-      command: () => editor.chain().focus().undo().run(),
-      optionName: "undo",
-      disabled: !editor.can().undo(),
-      active: editor.can().undo(),
-    },
-    {
-      Icon: Redo,
-      command: () => editor.chain().focus().redo().run(),
-      optionName: "redo",
-      disabled: !editor.can().redo(),
-      active: editor.can().redo(),
-    },
-  ];
-
   const renderOptionButton = ({
     Icon,
     command,
@@ -146,11 +131,7 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
       <EmojiOption editor={editor} />
       <LinkOption editor={editor} />
       {blockStyleOptions.map(renderOptionButton)}
-      {[listStyleOptions, editorOptions].map((optionGroup, index) => (
-        <React.Fragment key={index}>
-          {optionGroup.map(renderOptionButton)}
-        </React.Fragment>
-      ))}
+      {listStyleOptions.map(renderOptionButton)}
       <div className="neeto-editor-variables-button">
         <Variables editor={editor} variables={variables} />
       </div>

--- a/lib/components/Editor/CustomExtensions/FixedMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/index.js
@@ -24,7 +24,7 @@ import {
   ICON_COLOR_INACTIVE,
 } from "./constants";
 
-const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
+const FixedMenu = ({ editor, variables, setImageUploadVisible, options }) => {
   if (!editor) {
     return null;
   }
@@ -60,7 +60,7 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
       active: editor.isActive("highlight"),
       optionName: "highlight",
     },
-  ];
+  ].filter((item) => options.includes(item.optionName));
 
   const blockStyleOptions = [
     {
@@ -73,14 +73,14 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
       Icon: Code,
       command: () => editor.chain().focus().toggleCodeBlock().run(),
       active: editor.isActive("codeBlock"),
-      optionName: "codeBlock",
+      optionName: "code-block",
     },
     {
       Icon: Image,
       command: () => setImageUploadVisible(true),
       optionName: "image-upload",
     },
-  ];
+  ].filter((item) => options.includes(item.optionName));
 
   const listStyleOptions = [
     {
@@ -95,7 +95,12 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
       active: editor.isActive("orderedList"),
       optionName: "ordered-list",
     },
-  ];
+  ].filter((item) => options.includes(item.optionName));
+
+  const isTextColorActive = options.includes("font-color");
+  const isFontSizeActive = options.includes("font-size");
+  const isEmojiActive = options.includes("emoji");
+  const isLinkActive = options.includes("link");
 
   const renderOptionButton = ({
     Icon,
@@ -122,14 +127,16 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
 
   return (
     <div className="neeto-editor-fixed-menu">
-      <TextColorOption
-        color={editor.getAttributes("textStyle").color}
-        onChange={(color) => editor.chain().focus().setColor(color).run()}
-      />
-      <FontSizeOption editor={editor} />
+      {isTextColorActive && (
+        <TextColorOption
+          color={editor.getAttributes("textStyle").color}
+          onChange={(color) => editor.chain().focus().setColor(color).run()}
+        />
+      )}
+      {isFontSizeActive && <FontSizeOption editor={editor} />}
       {fontStyleOptions.map(renderOptionButton)}
-      <EmojiOption editor={editor} />
-      <LinkOption editor={editor} />
+      {isEmojiActive && <EmojiOption editor={editor} />}
+      {isLinkActive && <LinkOption editor={editor} />}
       {blockStyleOptions.map(renderOptionButton)}
       {listStyleOptions.map(renderOptionButton)}
       <div className="neeto-editor-variables-button">

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -13,7 +13,6 @@ import {
   ListNumber,
   Blockquote,
   Image,
-  Video,
   Code,
   Smiley,
 } from "@bigbinary/neeto-icons";
@@ -21,7 +20,7 @@ import {
 export const CommandsPluginKey = new PluginKey("commands");
 
 export default {
-  configure: ({ setImageUploadVisible }) =>
+  configure: ({ setImageUploadVisible, options }) =>
     Extension.create({
       addOptions() {
         return {
@@ -42,6 +41,7 @@ export default {
                   title: "Paragraph",
                   description: "Add a plain text block",
                   Icon: Paragraph,
+                  optionName: "font-size",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -55,6 +55,7 @@ export default {
                   title: "H1",
                   description: "Add a big heading",
                   Icon: TextH1,
+                  optionName: "font-size",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -68,6 +69,7 @@ export default {
                   title: "H2",
                   description: "Add a sub-heading",
                   Icon: TextH2,
+                  optionName: "font-size",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -81,6 +83,7 @@ export default {
                   title: "Numbered list",
                   description: "Add a list with numbering",
                   Icon: ListNumber,
+                  optionName: "ordered-list",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -94,6 +97,7 @@ export default {
                   title: "Bulleted list",
                   description: "Add an list bullets",
                   Icon: ListDot,
+                  optionName: "bullet-list",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -107,6 +111,7 @@ export default {
                   title: "Blockquote",
                   description: "Add a quote",
                   Icon: Blockquote,
+                  optionName: "block-quote",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -120,31 +125,17 @@ export default {
                   title: "Image",
                   description: "Add an image",
                   Icon: Image,
+                  optionName: "image-upload",
                   command: ({ editor, range }) => {
                     setImageUploadVisible(true);
                     editor.chain().focus().deleteRange(range).run();
                   },
                 },
-                // {
-                //   title: "Youtube/Vimeo",
-                //   description: "Embed a video from major services",
-                //   Icon: Video,
-                //   command: ({ editor, range }) => {
-                //     const embedURL = prompt(
-                //       "Please enter Youtube/Vimeo embed URL"
-                //     );
-                //     editor
-                //       .chain()
-                //       .focus()
-                //       .deleteRange(range)
-                //       .setExternalVideo({ src: embedURL })
-                //       .run();
-                //   },
-                // },
                 {
                   title: "Code block",
                   description: "Add a code block with syntax highlighting",
                   Icon: Code,
+                  optionName: "code-block",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -158,6 +149,7 @@ export default {
                   title: "Emoji",
                   description: "Add an emoji",
                   Icon: Smiley,
+                  optionName: "emoji",
                   command: ({ editor, range }) => {
                     editor
                       .chain()
@@ -167,7 +159,7 @@ export default {
                       .run();
                   },
                 },
-              ];
+              ].filter((item) => options.includes(item.optionName));
 
               const filteredItems = items.filter((item) =>
                 item.title.toLowerCase().includes(query.toLowerCase())

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -125,22 +125,22 @@ export default {
                     editor.chain().focus().deleteRange(range).run();
                   },
                 },
-                {
-                  title: "Youtube/Vimeo",
-                  description: "Embed a video from major services",
-                  Icon: Video,
-                  command: ({ editor, range }) => {
-                    const embedURL = prompt(
-                      "Please enter Youtube/Vimeo embed URL"
-                    );
-                    editor
-                      .chain()
-                      .focus()
-                      .deleteRange(range)
-                      .setExternalVideo({ src: embedURL })
-                      .run();
-                  },
-                },
+                // {
+                //   title: "Youtube/Vimeo",
+                //   description: "Embed a video from major services",
+                //   Icon: Video,
+                //   command: ({ editor, range }) => {
+                //     const embedURL = prompt(
+                //       "Please enter Youtube/Vimeo embed URL"
+                //     );
+                //     editor
+                //       .chain()
+                //       .focus()
+                //       .deleteRange(range)
+                //       .setExternalVideo({ src: embedURL })
+                //       .run();
+                //   },
+                // },
                 {
                   title: "Code block",
                   description: "Add a code block with syntax highlighting",

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -31,6 +31,7 @@ export default function useCustomExtensions({
   isSlashCommandsActive,
   showImageInMention,
   setImageUploadVisible,
+  options,
 }) {
   let customExtensions;
 
@@ -64,7 +65,9 @@ export default function useCustomExtensions({
     ];
 
     if (isSlashCommandsActive) {
-      customExtensions.push(SlashCommands.configure({ setImageUploadVisible }));
+      customExtensions.push(
+        SlashCommands.configure({ setImageUploadVisible, options })
+      );
     }
 
     if (!isEmpty(mentions)) {

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -53,7 +53,6 @@ const Tiptap = (
     "italic",
     "underline",
     "strike",
-    "highlight",
     "link",
     "bullet-list",
     "ordered-list",

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -12,15 +12,7 @@ const Tiptap = (
     forceTitle = false,
     titleError = false,
     hideSlashCommands = false,
-    formatterOptions = [
-      "bold",
-      "italic",
-      "underline",
-      "code",
-      "highlight",
-      "strike",
-      "link",
-    ],
+    addons = [],
     className,
     uploadEndpoint,
     initialValue = "",
@@ -54,6 +46,22 @@ const Tiptap = (
   const showSlashCommandPlaceholder =
     !isPlaceholderActive && isSlashCommandsActive;
 
+  const defaultOptions = [
+    "font-color",
+    "font-size",
+    "bold",
+    "italic",
+    "underline",
+    "strike",
+    "highlight",
+    "link",
+    "bullet-list",
+    "ordered-list",
+  ];
+  const allOptions = defaultOptions.concat(
+    addons.map((option) => option.toLowerCase())
+  );
+
   const customExtensions = useCustomExtensions({
     contentClassName,
     forceTitle,
@@ -64,6 +72,7 @@ const Tiptap = (
     isSlashCommandsActive,
     showImageInMention,
     setImageUploadVisible,
+    options: allOptions,
   });
 
   const editor = useEditor({
@@ -98,10 +107,11 @@ const Tiptap = (
           editor={editor}
           variables={variables}
           setImageUploadVisible={setImageUploadVisible}
+          options={allOptions}
         />
       )}
       {isBubbleMenuActive && (
-        <BubbleMenu editor={editor} formatterOptions={formatterOptions} />
+        <BubbleMenu editor={editor} options={allOptions} />
       )}
       <ImageUploader
         isVisible={isImageUploadVisible}


### PR DESCRIPTION
Fixes #57 
- Removed undo and redo options from the fixed menu.
- Removed video embed option from slash menu (file `Embed.js` not deleted).
- Converted the following options as `defaultOptions`:  font size, font color, bold, italics, underline, strike through, link, bulleted list and numbered list. These are always available.
- Converted the following options as `addons`: hightlight, emoji, code-block, block-quote, and image-upload. These are shown in the menu if the user provides the correct prop.
- Added documentation for `addons`.

@amaldinesh7 _a please have a look.