### PR TITLE
Fix link dropdown scrolling on focus issue, added enter to submit

### DIFF
--- a/lib/components/Common/Dropdown/index.js
+++ b/lib/components/Common/Dropdown/index.js
@@ -21,6 +21,7 @@ const Dropdown = forwardRef(
       icon,
       label,
       isOpen,
+      onVisible = noop,
       onClose = noop,
       ulProps,
       position,
@@ -67,7 +68,7 @@ const Dropdown = forwardRef(
     };
 
     const handleButtonClick = () => {
-      setVisibility(!visible);
+      !isControlled && setVisibility(!visible);
     };
 
     closeOnEsc && useHotkeys("esc", onPopupClose);
@@ -86,6 +87,10 @@ const Dropdown = forwardRef(
       isControlled && setVisibility(isOpen);
     }, [isOpen]);
 
+    useEffect(() => {
+      visible && onVisible();
+    }, [visible]);
+
     return (
       <div
         ref={wrapperRef}
@@ -96,10 +101,7 @@ const Dropdown = forwardRef(
         {...otherProps}
       >
         {customTarget ? (
-          <div
-            ref={setReference}
-            onClick={handleButtonClick}
-          >
+          <div ref={setReference} onClick={handleButtonClick}>
             {Target}
           </div>
         ) : (

--- a/lib/components/Editor/CustomExtensions/FixedMenu/LinkOption.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/LinkOption.js
@@ -57,7 +57,7 @@ const LinkOption = ({ editor }) => {
       closeOnSelect={false}
       position="bottom"
     >
-      <>
+      <form onSubmit={handleLink} className="neeto-editor-link__form">
         <Input
           name="url"
           value={urlString}
@@ -67,14 +67,9 @@ const LinkOption = ({ editor }) => {
           onChange={({ target: { value } }) => setUrlString(value)}
           autoFocus
         />
-        <Button label="Link" onClick={handleLink} />
-        {isActive && (
-          <Button
-            label="Unlink"
-            onClick={handleUnlink}
-          />
-        )}
-      </>
+        <Button label="Link" type="submit" />
+        {isActive && <Button label="Unlink" onClick={handleUnlink} />}
+      </form>
     </Dropdown>
   );
 };

--- a/lib/components/Editor/CustomExtensions/FixedMenu/LinkOption.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/LinkOption.js
@@ -14,6 +14,7 @@ import {
 
 const LinkOption = ({ editor }) => {
   const dropdownRef = useRef();
+  const inputRef = useRef();
   const [error, setError] = useState("");
   const [urlString, setUrlString] = useState("");
 
@@ -41,6 +42,11 @@ const LinkOption = ({ editor }) => {
   return (
     <Dropdown
       ref={dropdownRef}
+      onVisible={() =>
+        inputRef.current?.focus({
+          preventScroll: true,
+        })
+      }
       customTarget={() => (
         <button
           type="button"
@@ -59,13 +65,13 @@ const LinkOption = ({ editor }) => {
     >
       <form onSubmit={handleLink} className="neeto-editor-link__form">
         <Input
+          ref={inputRef}
           name="url"
           value={urlString}
           placeholder="Paste URL"
           onFocus={() => setError("")}
           error={error}
           onChange={({ target: { value } }) => setUrlString(value)}
-          autoFocus
         />
         <Button label="Link" type="submit" />
         {isActive && <Button label="Unlink" onClick={handleUnlink} />}

--- a/lib/styles/editor/_menu.scss
+++ b/lib/styles/editor/_menu.scss
@@ -84,14 +84,17 @@
 
 .neeto-editor-link-wrapper {
   .neeto-ui-dropdown__popup {
-    display: flex !important;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 12px;
     padding: 8px;
     width: 100%;
     max-width: 400px;
+
+    .neeto-editor-link__form {
+      display: flex !important;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 12px;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #107 
Part of #28 via https://github.com/bigbinary/neeto-editor-tiptap/pull/97#issuecomment-1000255310.
- Prevented auto-scrolling when opening link dropdown.
- Added ability to submit the link on pressing enter.

Demo: https://vimeo.com/660319920/46be705c21

@labeebklatif _a please have a look.