### PR TITLE
Added divider addon to slash commands

### DIFF
--- a/example/constants.js
+++ b/example/constants.js
@@ -124,7 +124,7 @@ export const EDITOR_PROP_TABLE_ROWS = [
   [
     "addons",
     "Accepts an array of strings, each corresponding to the name of an addon.",
-    `["highlight", "emoji", "code-block", "block-quote", "image-upload"]`,
+    `["highlight", "emoji", "code-block", "block-quote", "image-upload", "divider"]`,
   ],
   [
     "markdownMode",
@@ -152,6 +152,7 @@ export const SAMPLE_ADDONS = [
   "code-block",
   "block-quote",
   "image-upload",
+  "divider",
 ];
 
 export const EDITOR_ADDONS_TABLE_COLUMNS = ["Prop", "Description"];
@@ -162,6 +163,7 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
   ["code-block", "Provide syntax highlighting for code snippets."],
   ["block-quote", "Highlight a block of text as a quote."],
   ["image-upload", "Upload images to the editor."],
+  ["divider", "Add a horizontal line to separate different sections."],
 ];
 
 export const STRINGS = {
@@ -225,6 +227,7 @@ export const STRINGS = {
     "code-block",
     "block-quote",
     "image-upload",
+    "divider",
   ];
 
   <Editor addons={addons} />`,

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -159,6 +159,19 @@ export default {
                       .run();
                   },
                 },
+                {
+                  title: "Divider",
+                  description: "Add an horizontal line to separate sections",
+                  optionName: "divider",
+                  command: ({ editor, range }) => {
+                    editor
+                      .chain()
+                      .focus()
+                      .deleteRange(range)
+                      .setHorizontalRule()
+                      .run();
+                  },
+                },
               ].filter((item) => options.includes(item.optionName));
 
               const filteredItems = items.filter((item) =>

--- a/lib/styles/editor/_editor.scss
+++ b/lib/styles/editor/_editor.scss
@@ -93,6 +93,10 @@
     }
   }
 
+  hr {
+    margin: 8px 0;
+  }
+
   .ProseMirror-selectednode {
     outline: 3px solid $neeto-ui-pastel-blue;
   }


### PR DESCRIPTION
Fixes #110 
- Added a `divider` addon for slash commands.
- Added documentation for the `divider` addon.

@goutham-subramanyam _a please take a look: https://vimeo.com/660413365/f38b2723ce
cc: @karthiknmenon 