### PR TITLE
Added autoFocus prop for automatically focussing editor on load

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -46,7 +46,7 @@ const App = () => {
         </button>
       </div>
       <hr className="my-2 border-gray-100" />
-      <Editor ref={ref} />
+      <Editor ref={ref} autoFocus />
       <Heading type="sub">Features</Heading>
       <ListItems items={EDITOR_FEATURES} ordered />
       <Heading>Installation</Heading>

--- a/example/constants.js
+++ b/example/constants.js
@@ -153,6 +153,11 @@ export const EDITOR_PROP_TABLE_ROWS = [
     "Accepts a string value. This decides whether the editor height is fixed or flexible.",
     "fixed",
   ],
+  [
+    "autoFocus",
+    "Accepts a boolean value. When true, the editor will be focused on load.",
+    "true",
+  ],
 ];
 
 export const EDITOR_CONTENT_PROP_TABLE_ROWS = [

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import { useEditor, EditorContent } from "@tiptap/react";
 
@@ -35,6 +35,7 @@ const Tiptap = (
     editorSecrets,
     rows = 6,
     strategy = "fixed",
+    autoFocus = false,
     ...otherProps
   },
   ref
@@ -119,6 +120,10 @@ const Tiptap = (
     },
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
   });
+
+  useEffect(() => {
+    autoFocus && editor?.commands.focus("end");
+  }, [editor]);
 
   /* Make editor object available to the parent */
   React.useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Fixes #134, part of #132 
- Added `autoFocus` prop. If a truthy value is passed to the prop, it will immediately focus the editor on load.
- Added documentation for `autoFocus` prop.

NOTE: In the documentation, I have added `autoFocus` to the topmost editor. Else, the page automatically scrolls to the editor which has focus.

@labeebklatif _a please review.