### PR TITLE
Added option to submit editor content using keyboard shortcuts

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -277,6 +277,21 @@ const App = () => {
         <CodeBlock>{STRINGS.editorHeightSampleCode}</CodeBlock>
         <SampleEditor rows={3} strategy="flexible" />
       </div>
+      <Heading type="sub">
+        Submit editor content using keyboard shortcuts
+      </Heading>
+      <Description>
+        By default, Neeto Editor submits the content on pressing the{" "}
+        <HighlightText>⌘ + Enter</HighlightText> in Mac or{" "}
+        <HighlightText>Ctrl + Enter</HighlightText> in Windows. An{" "}
+        <HighlightText>onSubmit</HighlightText> prop can be provided to call a
+        function when the content is submitted. It accepts the resulting HTML
+        content as argument.
+      </Description>
+      <div className="flex mt-4">
+        <CodeBlock>{STRINGS.editorOnSubmitSampleCode}</CodeBlock>
+        <SampleEditor onSubmit={(content) => console.log(content)} />
+      </div>
     </div>
   );
 };

--- a/example/constants.js
+++ b/example/constants.js
@@ -158,6 +158,11 @@ export const EDITOR_PROP_TABLE_ROWS = [
     "Accepts a boolean value. When true, the editor will be focused on load.",
     "true",
   ],
+  [
+    "onSubmit",
+    "Accepts a function. This function will be invoked when the editor is submitted.",
+    "(htmlContent) => {}",
+  ],
 ];
 
 export const EDITOR_CONTENT_PROP_TABLE_ROWS = [
@@ -283,5 +288,13 @@ export const STRINGS = {
 
   editorHeightSampleCode: `
   <Editor rows={3} strategy="flexible" />
+  `,
+
+  editorOnSubmitSampleCode: `
+    const handleSubmit = (htmlContent) => {
+      console.log(htmlContent);
+    }
+
+    <Editor onSubmit={handleSubmit} />
   `,
 };

--- a/lib/components/Editor/CustomExtensions/KeyboardShortcuts/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/KeyboardShortcuts/ExtensionConfig.js
@@ -1,0 +1,18 @@
+import { Extension } from "@tiptap/core";
+
+const KeyboardShortcuts = ({ handleSubmit }) =>
+  Extension.create({
+    addKeyboardShortcuts() {
+      return {
+        "Mod-Enter": () => {
+          handleSubmit?.(this.editor.getHTML());
+          this.editor.commands.blur();
+          return true;
+        },
+      };
+    },
+  });
+
+export default {
+  configure: ({ handleSubmit }) => KeyboardShortcuts({ handleSubmit }),
+};

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -22,6 +22,7 @@ import Mention, { createMentionSuggestions } from "./Mention/ExtensionConfig";
 import Embeds from "./Embeds/ExtensionConfig";
 import EmojiSuggestion from "./Emoji/EmojiSuggestion/ExtensionConfig";
 import EmojiPicker from "./Emoji/EmojiPicker/ExtensionConfig";
+import KeyboardShortcuts from "./KeyboardShortcuts/ExtensionConfig";
 
 export default function useCustomExtensions({
   forceTitle,
@@ -34,6 +35,7 @@ export default function useCustomExtensions({
   setImageUploadVisible,
   options,
   characterLimit,
+  onSubmit,
 }) {
   let customExtensions;
 
@@ -67,6 +69,7 @@ export default function useCustomExtensions({
       CharacterCount.configure({
         limit: characterLimit,
       }),
+      KeyboardShortcuts.configure({ handleSubmit: onSubmit }),
     ];
 
     if (isSlashCommandsActive) {

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -36,6 +36,7 @@ const Tiptap = (
     rows = 6,
     strategy = "fixed",
     autoFocus = false,
+    onSubmit,
     ...otherProps
   },
   ref
@@ -87,6 +88,7 @@ const Tiptap = (
     setImageUploadVisible,
     options: allOptions,
     characterLimit,
+    onSubmit,
   });
 
   const editorClasses = classNames("neeto-editor", {


### PR DESCRIPTION
Fixes #136, part of #132
- Pressing the keyboard shortcut: `Cmd + Enter` or `Ctrl + Enter` now submits the editor content and removes its focus.
- An `onSubmit` prop may be optionally passed which would be called when the editor content is submitted.
- It may be possible to configure this new extension to add more custom keyboard shortcuts in the future.

@labeebklatif _a please review.