### PR TITLE
Added characterCountStrategy prop to control character count option

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -254,15 +254,28 @@ const App = () => {
         <CodeBlock>{STRINGS.markdownModeSampleCode}</CodeBlock>
         <SampleEditor markdownMode />
       </div>
-      <Heading type="sub">Support for character limit</Heading>
+      <Heading type="sub">Support for character count</Heading>
+      <h3 className="mt-4 mb-2 font-bold">Character count and word count</h3>
       <Description>
-        Neeto Editor can be configured to enforce a character limit. This can be
-        done by providing an integer value to the{" "}
-        <HighlightText>characterLimit</HighlightText> prop.
+        Neeto Editor can be configured to show the character count as and word
+        count. This can be achieved by providing the{" "}
+        <HighlightText>characterCountStrategy</HighlightText> prop with the
+        string value <HighlightText>count</HighlightText>.
       </Description>
       <div className="flex">
+        <CodeBlock>{STRINGS.characterCountSampleCode}</CodeBlock>
+        <SampleEditor characterCountStrategy="count" />
+      </div>
+      <h3 className="mt-4 mb-2 font-bold">Character limit</h3>
+      Neeto Editor can be configured to enforce a character limit. This can be
+      done by providing an integer value to the{" "}
+      <HighlightText>characterLimit</HighlightText> prop. Additionally, provide
+      the <HighlightText>characterCountStrategy</HighlightText> prop with the
+      string value <HighlightText>limit</HighlightText> to display the number of
+      characters remaining.
+      <div className="flex">
         <CodeBlock>{STRINGS.characterLimitSampleCode}</CodeBlock>
-        <SampleEditor characterLimit={100} />
+        <SampleEditor characterCountStrategy="limit" characterLimit={100} />
       </div>
       <Heading type="sub">Control editor height</Heading>
       <Description>

--- a/example/App.js
+++ b/example/App.js
@@ -275,7 +275,7 @@ const App = () => {
       </Description>
       <div className="flex mt-4">
         <CodeBlock>{STRINGS.editorHeightSampleCode}</CodeBlock>
-        <SampleEditor rows={3} strategy="flexible" />
+        <SampleEditor rows={3} heightStrategy="flexible" />
       </div>
       <Heading type="sub">
         Submit editor content using keyboard shortcuts

--- a/example/constants.js
+++ b/example/constants.js
@@ -163,6 +163,11 @@ export const EDITOR_PROP_TABLE_ROWS = [
     "Accepts a function. This function will be invoked when the editor is submitted.",
     "(htmlContent) => {}",
   ],
+  [
+    "characterCountStrategy",
+    "Accepts a string value. This decides on how the character count should be displayed.",
+    "limit",
+  ],
 ];
 
 export const EDITOR_CONTENT_PROP_TABLE_ROWS = [
@@ -282,8 +287,15 @@ export const STRINGS = {
   <Editor markdownMode />
   `,
 
+  characterCountSampleCode: `
+  <Editor characterCountStrategy="count" />
+  `,
+
   characterLimitSampleCode: `
-  <Editor characterLimit={100} />
+  <Editor
+    characterCountStrategy="limit"
+    characterLimit={100}
+  />
   `,
 
   editorHeightSampleCode: `

--- a/example/constants.js
+++ b/example/constants.js
@@ -149,7 +149,7 @@ export const EDITOR_PROP_TABLE_ROWS = [
     "6",
   ],
   [
-    "strategy",
+    "heightStrategy",
     "Accepts a string value. This decides whether the editor height is fixed or flexible.",
     "fixed",
   ],
@@ -287,7 +287,7 @@ export const STRINGS = {
   `,
 
   editorHeightSampleCode: `
-  <Editor rows={3} strategy="flexible" />
+  <Editor rows={3} heightStrategy="flexible" />
   `,
 
   editorOnSubmitSampleCode: `

--- a/lib/components/Editor/CustomExtensions/CharacterCount/index.js
+++ b/lib/components/Editor/CustomExtensions/CharacterCount/index.js
@@ -1,11 +1,17 @@
 import React from "react";
 
-const CharacterCount = ({ editor, characterLimit }) => {
+const CharacterCount = ({ editor, limit, strategy }) => {
+  if (strategy === "hidden") {
+    return null;
+  }
+
+  const characterLimitActive = strategy === "limit" && limit;
+
   return (
     <p className="neeto-editor-character-count">
-      {characterLimit
+      {characterLimitActive
         ? `${
-            characterLimit - editor?.storage?.characterCount?.characters()
+            limit - editor?.storage?.characterCount?.characters()
           } characters remaining`
         : `${editor?.storage?.characterCount?.characters()} characters, ${editor?.storage?.characterCount?.words()} words`}
     </p>

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -37,6 +37,7 @@ const Tiptap = (
     strategy = "fixed",
     autoFocus = false,
     onSubmit,
+    characterCountStrategy = "hidden",
     ...otherProps
   },
   ref
@@ -172,7 +173,11 @@ const Tiptap = (
       ) : (
         <EditorContent editor={editor} {...otherProps} />
       )}
-      <CharacterCount editor={editor} characterLimit={characterLimit} />
+      <CharacterCount
+        editor={editor}
+        limit={characterLimit}
+        strategy={characterCountStrategy}
+      />
     </div>
   );
 };

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -34,9 +34,9 @@ const Tiptap = (
     characterLimit,
     editorSecrets,
     rows = 6,
-    strategy = "fixed",
     autoFocus = false,
     onSubmit,
+    heightStrategy = "fixed",
     characterCountStrategy = "hidden",
     ...otherProps
   },
@@ -103,7 +103,7 @@ const Tiptap = (
   });
 
   const editorHeightAttrName =
-    strategy === "flexible" ? "min-height" : "height";
+    heightStrategy === "flexible" ? "min-height" : "height";
   const editorHeightAttrValue =
     rows * EDITOR_LINE_HEIGHT + 2 * (EDITOR_PADDING_SIZE + EDITOR_BORDER_SIZE);
 
@@ -165,7 +165,7 @@ const Tiptap = (
       {isMarkdownTabActive ? (
         <MarkdownEditor
           editor={editor}
-          strategy={strategy}
+          strategy={heightStrategy}
           style={editorStyles}
           className={editorClasses}
           {...otherProps}


### PR DESCRIPTION
Fixes #138, part of #132
- Added `characterCountStrategy` prop. It will take three values:
  1. `hidden`: Character count is disabled. (default)
  2. `limit`: This shows the number of characters that could be typed.
  3. `count`: This shows the number of characters and words that are currently entered.
- Renamed `strategy` prop to `heightStrategy` to avoid confusions.
- Updated documentation for character count.

@labeebklatif _a please review.