### PR TITLE
Updated initialValue prop to value prop to make editor controlled

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -195,7 +195,7 @@ const App = () => {
       <div className="flex">
         <CodeBlock>{STRINGS.forceTitleSampleCode}</CodeBlock>
         <SampleEditor
-          initialValue="Title Text"
+          value="Title Text"
           placeholder={{
             title: "Input title here",
             paragraph: "Enter your content here",
@@ -316,7 +316,7 @@ const SampleEditor = (props) => {
 
   return (
     <div className="flex-1 mx-3 my-2 h-60">
-      <Editor ref={ref} initialValue="Edit Text Content" {...props} />
+      <Editor ref={ref} value="Edit Text Content" {...props} />
     </div>
   );
 };

--- a/example/constants.js
+++ b/example/constants.js
@@ -52,8 +52,8 @@ export const EDITOR_PROP_TABLE_ROWS = [
     `React.createRef()`,
   ],
   [
-    "initialValue",
-    "Accepts a valid HTML string. This string will be parsed to HTML and will be displayed as initial editor content",
+    "value",
+    "Accepts a valid HTML string. This string will be parsed to HTML and will be displayed as the editor content",
     `"<p>Hello World</p"`,
   ],
   [

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -22,7 +22,7 @@ const Tiptap = (
     markdownMode = false,
     className,
     uploadEndpoint,
-    initialValue = "",
+    value = "",
     onChange = () => {},
     menuType = "fixed",
     variables,
@@ -113,7 +113,7 @@ const Tiptap = (
 
   const editor = useEditor({
     extensions: customExtensions,
-    content: initialValue,
+    content: value,
     injectCSS: false,
     editorProps: {
       attributes: {
@@ -127,6 +127,10 @@ const Tiptap = (
   useEffect(() => {
     autoFocus && editor?.commands.focus("end");
   }, [editor]);
+
+  useEffect(() => {
+    editor?.commands.setContent(value);
+  }, [value]);
 
   /* Make editor object available to the parent */
   React.useImperativeHandle(ref, () => ({

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -129,7 +129,9 @@ const Tiptap = (
   }, [editor]);
 
   useEffect(() => {
-    editor?.commands.setContent(value);
+    typeof value === "string"
+      ? editor?.commands.setContent(value)
+      : editor?.commands.setContent("");
   }, [value]);
 
   /* Make editor object available to the parent */


### PR DESCRIPTION
Fixes part of #146

- Changed `initialValue` prop to `value` prop.
- The editor can now act as a controlled component just like a Textarea component. Value can be externally controlled using states.
- Advantages
  1. Reset the editor content using external states.
  2. Insert external content into editor.

Demo: https://vimeo.com/667777875/9fc52132ea

Ref: 
1. https://github.com/bigbinary/neeto-desk-web/pull/11901#issuecomment-1015686016
2. https://github.com/bigbinary/neeto-desk-web/issues/11838
3. https://github.com/bigbinary/neeto-planner-web/pull/536

@labeebklatif _a please take a look at the same.
Fully replace App.js with this [gist](https://gist.github.com/AbhayVAshokan/f6b911fa45b217c8c3ebd8325392c549) to replicate my UI.

cc: @vysakh-poulose 