### PR TITLE
Fixed problems with controlled editor

### DIFF
--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -10,11 +10,11 @@ const MarkdownEditor = ({
   strategy,
   onChange,
   onSubmit,
-  initialValue,
+  value,
   ...otherProps
 }) => {
   const [content, setContent] = useState(() =>
-    htmlToMarkdown(editor?.getHTML() || initialValue)
+    htmlToMarkdown(editor?.getHTML() || value)
   );
 
   const textareaRef = useRef();

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -168,7 +168,7 @@ const Tiptap = (
           className={editorClasses}
           onChange={onChange}
           onSubmit={onSubmit}
-          initialValue={initialValue}
+          value={value}
           {...otherProps}
         />
       )}

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -74,6 +74,8 @@ const Tiptap = (
   const addonOptions = addons.map((option) => option.toLowerCase());
   isUnsplashImageUploadActive && addonOptions.push("image-upload");
   const allOptions = defaultOptions.concat(addonOptions);
+  const formattedValue =
+    typeof value === "string" ? value.replaceAll(" ", "&nbsp;") : "";
 
   const customExtensions = useCustomExtensions({
     contentClassName,
@@ -111,7 +113,7 @@ const Tiptap = (
 
   const editor = useEditor({
     extensions: customExtensions,
-    content: value,
+    content: formattedValue,
     injectCSS: false,
     editorProps: {
       attributes: {
@@ -127,9 +129,7 @@ const Tiptap = (
   }, [editor]);
 
   useEffect(() => {
-    typeof value === "string"
-      ? editor?.commands.setContent(value)
-      : editor?.commands.setContent("");
+    editor?.commands.setContent(formattedValue);
   }, [value]);
 
   /* Make editor object available to the parent */
@@ -168,7 +168,7 @@ const Tiptap = (
           className={editorClasses}
           onChange={onChange}
           onSubmit={onSubmit}
-          value={value}
+          value={formattedValue}
           {...otherProps}
         />
       )}

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -129,7 +129,9 @@ const Tiptap = (
   }, [editor]);
 
   useEffect(() => {
+    const cursorPosition = editor?.state.selection.anchor;
     editor?.commands.setContent(formattedValue);
+    editor?.commands.setTextSelection(cursorPosition);
   }, [value]);
 
   /* Make editor object available to the parent */


### PR DESCRIPTION
Fixes #151 

- `initialValue` prop replaced with `value` prop in markdown mode. This prevents the app from crashing when switched to markdown mode.
- Prevented the cursor from moving to the end when a character is typed in a controlled editor.
- Permit typing multiple trailing spaces in a controlled editor. Earlier, when multiple spaces were typed, the editor immediately trimmed it off.

- Please fully replace `example/App.js` file with this [gist](https://gist.github.com/AbhayVAshokan/28e133300447d1f4745c75d6a692e7b3) to recreate my UI. Also please do go through this video for explanation + demo: https://vimeo.com/670741971/bb2aae555b

@labeebklatif _a please review the changes.

cc: @AJIL-PAUL 
- Please report further issues (if any). Also do try out the changes in this branch locally.