### PR TITLE
Added a common response for markdown and RichText, fixed issues with space

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -29,6 +29,7 @@ import Table from "./components/Table";
 const App = () => {
   const ref = useRef();
   const [isMarkdownModeActive, setIsMarkdownModeActive] = useState(false);
+  const [editorContent, setEditorContent] = useState("<p>Initial Content</p>");
 
   const getHTML = () => {
     return ref.current.editor.getHTML();
@@ -323,6 +324,22 @@ const App = () => {
       <div className="flex mt-4">
         <CodeBlock>{STRINGS.editorOnSubmitSampleCode}</CodeBlock>
         <SampleEditor onSubmit={(content) => console.log(content)} />
+      </div>
+      <Heading type="sub">Using the editor as a controlled component</Heading>
+      <Description>
+        By default, the editor acts like an uncontrolled component. It can be{" "}
+        controlled by passing the <HighlightText>value</HighlightText> prop and{" "}
+        an <HighlightText>onChange</HighlightText> prop. The{" "}
+        <HighlightText>onChange</HighlightText> prop accepts the html content as
+        argument.
+      </Description>
+      <div className="flex mt-4">
+        <CodeBlock>{STRINGS.editorControlledSampleCode}</CodeBlock>
+        <SampleEditor
+          value={editorContent}
+          onChange={setEditorContent}
+          onSubmit={(content) => console.log(content)}
+        />
       </div>
     </div>
   );

--- a/example/constants.js
+++ b/example/constants.js
@@ -324,4 +324,16 @@ export const STRINGS = {
 
     <Editor onSubmit={handleSubmit} />
   `,
+  editorControlledSampleCode: `
+    const [editorContent, setEditorContent] = useState("<p>Initial Content</p>");
+
+    const handleSubmit = (htmlContent) => {
+      console.log(htmlContent);
+    }
+
+    <Editor
+      content={editorContent}
+      onChange={setEditorContent}
+      onSubmit={handleSubmit}
+    />`,
 };

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -44,7 +44,7 @@ const MarkdownEditor = ({
 
   const handleChange = (e) => {
     setContent(e.target.value);
-    onChange?.(e.target.value);
+    onChange?.(markdownToHtml(e.target.value));
   };
 
   // Submit on Ctrl+Enter and Cmd+Enter

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -7,7 +7,6 @@ import {
   EDITOR_LINE_HEIGHT,
   EDITOR_BORDER_SIZE,
 } from "constants/common";
-import { replaceWithNonBreakingSpace } from "utils/common";
 
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
@@ -78,7 +77,6 @@ const Tiptap = (
   const addonOptions = addons.map((option) => option.toLowerCase());
   isUnsplashImageUploadActive && addonOptions.push("image-upload");
   const allOptions = defaultOptions.concat(addonOptions);
-  const formattedValue = replaceWithNonBreakingSpace(value);
 
   const customExtensions = useCustomExtensions({
     contentClassName,
@@ -116,7 +114,7 @@ const Tiptap = (
 
   const editor = useEditor({
     extensions: customExtensions,
-    content: formattedValue,
+    content: value,
     injectCSS: false,
     editorProps: {
       attributes: {
@@ -133,7 +131,9 @@ const Tiptap = (
 
   useEffect(() => {
     const cursorPosition = editor?.state.selection.anchor;
-    editor?.commands.setContent(formattedValue);
+    typeof value === "string"
+      ? editor?.commands.setContent(value)
+      : editor?.commands.setContent("");
     editor?.commands.setTextSelection(cursorPosition);
   }, [value]);
 
@@ -173,7 +173,7 @@ const Tiptap = (
           className={editorClasses}
           onChange={onChange}
           onSubmit={onSubmit}
-          value={formattedValue}
+          value={value}
           {...otherProps}
         />
       )}

--- a/lib/styles/editor/_editor.scss
+++ b/lib/styles/editor/_editor.scss
@@ -9,7 +9,6 @@
 .neeto-editor {
   max-width: 100% !important;
   border-radius: $neeto-ui-rounded-sm;
-  white-space: pre-wrap;
   padding: 12px;
   color: $neeto-ui-gray-800;
 

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -11,13 +11,3 @@ export const hyphenize = (string) => {
     return fallbackString;
   }
 };
-
-// Replace all spaces within tags with "nbsp;". This prevents tiptap editor from removing trailing spaces while typing.
-export const replaceWithNonBreakingSpace = (value) => {
-  if (typeof value !== "string") return "";
-  return value.replaceAll(
-    /<(\S*?)[^>]*>(.*?)<\/\1>/g,
-    (_match, tag, content) =>
-      `<${tag}>${content.replaceAll(" ", "&nbsp;")}</${tag}>`
-  );
-};


### PR DESCRIPTION
Fixes #158
- Both markdown mode and rich text mode will now have a common response (HTML content). This makes it possible to initialize the editor with the stored value.
- Fixed the issue with word count by updating the logic related to the removal of trailing spaces.
- Added documentation for controlled editor mode.

Explanation: https://vimeo.com/674738686/f0fadd83cb