### PR TITLE
Removed multiple instances of slash commands

### DIFF
--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -220,6 +220,9 @@ export default {
 
               return {
                 onStart: (props) => {
+                  const node = document.querySelector('[id^="tippy"]');
+                  node && node.remove();
+
                   reactRenderer = new ReactRenderer(CommandsList, {
                     props,
                     editor: props.editor,
@@ -248,8 +251,8 @@ export default {
                   return reactRenderer.ref?.onKeyDown(props);
                 },
                 onExit() {
-                  popup[0].destroy();
-                  reactRenderer.destroy();
+                  popup && popup[0].destroy();
+                  reactRenderer && reactRenderer.destroy();
                 },
               };
             },

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -7,6 +7,7 @@ import {
   EDITOR_LINE_HEIGHT,
   EDITOR_BORDER_SIZE,
 } from "constants/common";
+import { replaceWithNonBreakingSpace } from "utils/common";
 
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
@@ -134,7 +135,7 @@ const Tiptap = (
   useEffect(() => {
     const cursorPosition = editor?.state.selection.anchor;
     typeof value === "string"
-      ? editor?.commands.setContent(value)
+      ? editor?.commands.setContent(replaceWithNonBreakingSpace(value))
       : editor?.commands.setContent("");
     editor?.commands.setTextSelection(cursorPosition);
   }, [value]);

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -24,3 +24,13 @@ export const hyphenize = (string) => {
     return fallbackString;
   }
 };
+
+// Replace all spaces within tags with "nbsp;". This prevents tiptap editor from removing trailing spaces while typing.
+export const replaceWithNonBreakingSpace = (value) => {
+  if (typeof value !== "string") return "";
+  return value.replaceAll(
+    /<(\S*?)[^>]*>(.*?)<\/\1>/g,
+    (_match, tag, content) =>
+      `<${tag}>${content.replaceAll(" ", "&nbsp;")}</${tag}>`
+  );
+};


### PR DESCRIPTION
Fixes #176
- Fixed the issue where multiple instances of slash commands are created. This prevents one tippy instance to be closed using keyboard navigation.
- Fixed the issue with trailing spaces getting removed.

