### PR TITLE
Removed controlled mode

### DIFF
--- a/example/App.jsx
+++ b/example/App.jsx
@@ -23,13 +23,16 @@ import {
   SAMPLE_ADDONS,
   EDITOR_ADDONS_TABLE_ROWS,
   EDITOR_ADDONS_TABLE_COLUMNS,
+  EDITOR_METHODS_TABLE_COLUMNS,
+  EDITOR_METHODS_TABLE_ROWS,
+  EDITOR_COMMANDS_TABLE_COLUMNS,
+  EDITOR_COMMANDS_TABLE_ROWS,
 } from "./constants";
 import Table from "./components/Table";
 
 const App = () => {
   const ref = useRef();
   const [isMarkdownModeActive, setIsMarkdownModeActive] = useState(false);
-  const [editorContent, setEditorContent] = useState("<p>Initial Content</p>");
 
   const getHTML = () => {
     return ref.current.editor.getHTML();
@@ -366,6 +369,66 @@ const App = () => {
         <CodeBlock>{STRINGS.editorOnSubmitSampleCode}</CodeBlock>
         <SampleEditor onSubmit={(content) => console.log(content)} />
       </div>
+      <Heading>Editor API</Heading>
+      <Description>
+        The editor API contains a number of methods and commands which can be
+        used to interact with the editor instance. This section will cover the
+        most important ones.
+      </Description>
+      <Heading type="sub">Methods</Heading>
+      <Description>
+        The editor instance will provide a bunch of useful methods. Here is a
+        list of methods that can be access the editor content.
+      </Description>
+      <Table
+        columns={EDITOR_METHODS_TABLE_COLUMNS}
+        rows={EDITOR_METHODS_TABLE_ROWS}
+        className="prop-detail-table"
+      />
+      <h3 className="mt-4 mb-2 font-bold">Usage</h3>
+      <CodeBlock>editorRef.current.editor.methodName</CodeBlock>
+      <Description>
+        Refer{" "}
+        <a
+          className="text-blue-500 font-medium"
+          href="https://tiptap.dev/api/editor"
+          target="_blank"
+          rel="noreferrer"
+        >
+          https://tiptap.dev/api/editor
+        </a>{" "}
+        for the full list of available editor methods.{" "}
+      </Description>
+      <Heading type="sub">Commands</Heading>
+      <Description>
+        The editor instance will provide a bunch of useful commands. Here is a
+        list of commands to control the editor content.
+      </Description>
+      <Table
+        columns={EDITOR_COMMANDS_TABLE_COLUMNS}
+        rows={EDITOR_COMMANDS_TABLE_ROWS}
+        className="prop-detail-table"
+      />
+      <h3 className="mt-4 mb-2 font-bold">Usage</h3>
+      <CodeBlock>editorRef.current.editor.commands.commandName()</CodeBlock>
+      <Description>
+        You can also combine multiple commands in a single call.
+      </Description>
+      <CodeBlock>
+        editorRef.current.editor.chain().command1().command2().run()
+      </CodeBlock>
+      <Description>
+        Refer{" "}
+        <a
+          className="text-blue-500 font-medium"
+          href="https://tiptap.dev/api/commands"
+          target="_blank"
+          rel="noreferrer"
+        >
+          https://tiptap.dev/api/commands
+        </a>{" "}
+        for the full list of available editor commands.{" "}
+      </Description>
     </div>
   );
 };

--- a/example/App.jsx
+++ b/example/App.jsx
@@ -440,7 +440,7 @@ const SampleEditor = (props) => {
 
   return (
     <div className="flex-1 mx-3 my-2 h-60">
-      <Editor ref={ref} value="Edit Text Content" {...props} />
+      <Editor ref={ref} initialValue="Edit Text Content" {...props} />
     </div>
   );
 };

--- a/example/App.jsx
+++ b/example/App.jsx
@@ -366,22 +366,6 @@ const App = () => {
         <CodeBlock>{STRINGS.editorOnSubmitSampleCode}</CodeBlock>
         <SampleEditor onSubmit={(content) => console.log(content)} />
       </div>
-      <Heading type="sub">Using the editor as a controlled component</Heading>
-      <Description>
-        By default, the editor acts like an uncontrolled component. It can be{" "}
-        controlled by passing the <HighlightText>value</HighlightText> prop and{" "}
-        an <HighlightText>onChange</HighlightText> prop. The{" "}
-        <HighlightText>onChange</HighlightText> prop accepts the html content as
-        argument.
-      </Description>
-      <div className="flex mt-4">
-        <CodeBlock>{STRINGS.editorControlledSampleCode}</CodeBlock>
-        <SampleEditor
-          value={editorContent}
-          onChange={setEditorContent}
-          onSubmit={(content) => console.log(content)}
-        />
-      </div>
     </div>
   );
 };

--- a/example/constants.js
+++ b/example/constants.js
@@ -221,6 +221,37 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
   ["video-embed", "Embed videos from YouTube and Vimeo."],
 ];
 
+export const EDITOR_METHODS_TABLE_COLUMNS = ["Method", "Description"];
+
+export const EDITOR_METHODS_TABLE_ROWS = [
+  ["getHTML()", "Returns the editor content as a valid HTML string."],
+  ["getText()", "Returns the editor content as a plain text."],
+  ["getJSON()", "Returns the editor content as a JSON object."],
+  ["setEditable(bool)", "Controls whether the editor can be editable or not."],
+  [
+    "isEditable",
+    "Returns a boolean value indicating whether the editor is editable or not.",
+  ],
+  [
+    "isEmpty",
+    "Returns a boolean value indicating whether the editor is empty or not.",
+  ],
+];
+
+export const EDITOR_COMMANDS_TABLE_COLUMNS = ["Command", "Description"];
+
+export const EDITOR_COMMANDS_TABLE_ROWS = [
+  ["clearContent()", "Clear the entire editor content."],
+  ["insertContent(content)", "Insert content at the current cursor position."],
+  ["insertContentAt(position, content)", "Insert content at the given index."],
+  [
+    "setContent(content)",
+    "Replace the whole editor content with the given content.",
+  ],
+  ["focus()", "Focus the editor."],
+  ["blur()", "Removes focus from the editor."],
+];
+
 export const STRINGS = {
   fixedMenuSampleCode: `
   <Editor />`,

--- a/example/constants.js
+++ b/example/constants.js
@@ -329,16 +329,4 @@ export const STRINGS = {
 
     <Editor onSubmit={handleSubmit} />
   `,
-  editorControlledSampleCode: `
-    const [editorContent, setEditorContent] = useState("<p>Initial Content</p>");
-
-    const handleSubmit = (htmlContent) => {
-      console.log(htmlContent);
-    }
-
-    <Editor
-      content={editorContent}
-      onChange={setEditorContent}
-      onSubmit={handleSubmit}
-    />`,
 };

--- a/example/constants.js
+++ b/example/constants.js
@@ -62,7 +62,7 @@ export const EDITOR_PROP_TABLE_ROWS = [
     `React.createRef()`,
   ],
   [
-    "value",
+    "initialValue",
     "Accepts a valid HTML string. This string will be parsed to HTML and will be displayed as the editor content",
     `"<p>Hello World</p"`,
   ],

--- a/lib/components/Editor/CustomExtensions/Embeds/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Embeds/ExtensionConfig.js
@@ -51,9 +51,11 @@ export default Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return [
-      "div",
-      { class: "video-wrapper" },
-      ["iframe", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)],
+      "iframe",
+      mergeAttributes(this.options.HTMLAttributes, {
+        ...HTMLAttributes,
+        class: "video-wrapper",
+      }),
     ];
   },
 

--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/EmojiSuggestionMenu.js
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/EmojiSuggestionMenu.js
@@ -89,7 +89,7 @@ class EmojiSuggestionMenu extends React.Component {
               key={emoji.id}
               onClick={() => this.selectItem(index)}
               className={classnames("neeto-editor-emoji-suggestion__item", {
-                "neeto-editor-emoji-suggestion__item--highlight":
+                "neeto-editor-emoji-suggestion__item--selected":
                   index === this.state.selectedIndex,
               })}
               data-cy={`neeto-editor-emoji-suggestion-${emoji.id}`}

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -10,11 +10,11 @@ const MarkdownEditor = ({
   strategy,
   onChange,
   onSubmit,
-  value,
+  initialValue,
   ...otherProps
 }) => {
   const [content, setContent] = useState(() =>
-    htmlToMarkdown(editor?.getHTML() || value)
+    htmlToMarkdown(editor?.getHTML() || initialValue)
   );
 
   const textareaRef = useRef();

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -82,9 +82,6 @@ export default {
 
               return {
                 onStart: (props) => {
-                  const node = document.querySelector('[id^="tippy"]');
-                  node && node.remove();
-
                   reactRenderer = new ReactRenderer(CommandsList, {
                     props,
                     editor: props.editor,

--- a/lib/components/Editor/EditorContent.js
+++ b/lib/components/Editor/EditorContent.js
@@ -4,7 +4,7 @@ import DOMPurify from "dompurify";
 import classnames from "classnames";
 import { EDITOR_CONTENT_CLASSNAME } from "../../constants/common";
 
-const EditorContent = ({ content = "", classNames, ...otherProps }) => {
+const EditorContent = ({ content = "", className, ...otherProps }) => {
   useEffect(() => {
     // Highlight codeblocks;
     highlightCode();
@@ -13,7 +13,7 @@ const EditorContent = ({ content = "", classNames, ...otherProps }) => {
   return (
     <div
       className={classnames(EDITOR_CONTENT_CLASSNAME, {
-        [classNames]: classNames,
+        [className]: className,
       })}
       dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
       data-cy="neeto-editor-content"

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -89,6 +89,7 @@ const Editor = (
     extensions: customExtensions,
     content: initialValue,
     injectCSS: false,
+    autofocus: autoFocus && "end",
     editorProps: {
       attributes: {
         class: editorClasses,
@@ -97,10 +98,6 @@ const Editor = (
     },
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
   });
-
-  useEffect(() => {
-    autoFocus && editor?.commands.focus("end");
-  }, [editor]);
 
   /* Make editor object available to the parent */
   React.useImperativeHandle(ref, () => ({

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -23,7 +23,7 @@ const Editor = (
     markdownMode = false,
     className,
     uploadEndpoint,
-    value = "",
+    initialValue = "",
     onChange = () => {},
     menuType = "fixed",
     variables,
@@ -87,7 +87,7 @@ const Editor = (
 
   const editor = useEditor({
     extensions: customExtensions,
-    content: value,
+    content: initialValue,
     injectCSS: false,
     editorProps: {
       attributes: {
@@ -138,7 +138,7 @@ const Editor = (
           className={editorClasses}
           onChange={onChange}
           onSubmit={onSubmit}
-          value={value}
+          initialValue={initialValue}
           {...otherProps}
         />
       )}

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import { useEditor, EditorContent } from "@tiptap/react";
-import { replaceWithNonBreakingSpace } from "utils/common";
-
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
 import ImageUploader from "./CustomExtensions/Image/Uploader";
@@ -103,14 +101,6 @@ const Editor = (
   useEffect(() => {
     autoFocus && editor?.commands.focus("end");
   }, [editor]);
-
-  useEffect(() => {
-    const cursorPosition = editor?.state.selection.anchor;
-    typeof value === "string"
-      ? editor?.commands.setContent(replaceWithNonBreakingSpace(value))
-      : editor?.commands.setContent("");
-    editor?.commands.setTextSelection(cursorPosition);
-  }, [value]);
 
   /* Make editor object available to the parent */
   React.useImperativeHandle(ref, () => ({

--- a/lib/styles/editor/_editor-content.scss
+++ b/lib/styles/editor/_editor-content.scss
@@ -83,15 +83,9 @@
 
   // Embed
   .video-wrapper {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: flex-start;
-
-    iframe {
-      width: 560px;
-      height: 315px;
-    }
+    width: 560px;
+    height: 315px;
+    margin: auto;
   }
 }
 

--- a/lib/styles/editor/_editor.scss
+++ b/lib/styles/editor/_editor.scss
@@ -9,6 +9,7 @@
 .neeto-editor {
   max-width: 100% !important;
   border-radius: $neeto-ui-rounded-sm;
+  white-space: pre-wrap;
   padding: 12px;
   color: $neeto-ui-gray-800;
 

--- a/lib/styles/editor/_emoji.scss
+++ b/lib/styles/editor/_emoji.scss
@@ -79,4 +79,8 @@
       background-color: $neeto-ui-gray-200;
     }
   }
+
+  .neeto-editor-emoji-suggestion__item--selected {
+    background-color: $neeto-ui-gray-200;
+  }
 }

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -27,16 +27,6 @@ export const hyphenize = (string) => {
   }
 };
 
-// Replace all spaces within tags with "nbsp;". This prevents tiptap editor from removing trailing spaces while typing.
-export const replaceWithNonBreakingSpace = (value) => {
-  if (typeof value !== "string") return "";
-  return value.replaceAll(
-    /<(\S*?)[^>]*>(.*?)<\/\1>/g,
-    (_match, tag, content) =>
-      `<${tag}>${content.replaceAll(" ", "&nbsp;")}</${tag}>`
-  );
-};
-
 export const stringifyObject = (object, separator = ";") =>
   Object.entries(object).reduce(
     (acc, [key, value]) => (acc += `${key}:${value}${separator}`),

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -6,7 +6,7 @@ export const markdownToHtml = (data) => {
   // Convert \ to empty <p> tag (blank line)
   data = data.replaceAll(/^\\$/gm, "<p></p>");
 
-  let parsedHTML = marked.parse(data);
+  let parsedHTML = marked.parse(data, { sanitize: false });
 
   // Remove <p> tag just outside <img> tag
   parsedHTML = parsedHTML.replaceAll(/<p><img[^>]*><\/p>/g, (match) =>
@@ -25,7 +25,7 @@ export const markdownToHtml = (data) => {
   // Convert --text-- to <u>text</u>
   parsedHTML = parsedHTML.replaceAll(/--([^-]+)--/g, "<u>$1</u>");
 
-  return DOMPurify.sanitize(parsedHTML);
+  return DOMPurify.sanitize(parsedHTML, { ADD_TAGS: ["iframe"] });
 };
 
 export const htmlToMarkdown = (data) => {
@@ -34,6 +34,7 @@ export const htmlToMarkdown = (data) => {
     codeBlockStyle: "fenced",
     blankReplacement: (_content, node) => (node.isBlock ? "\\\n" : ""),
   });
+  turndownService.keep(["iframe"]);
 
   // Strike through rule: ~strike~
   turndownService.addRule("strikethrough", {


### PR DESCRIPTION
Fixes #192 
Fixes #184 since it is specific to the controlled editor. Works perfectly in uncontrolled mode.

Removed controlled mode from editor. Here are some notable changes.
1. Removed logic added specifically for controlled editor:
1.1. Remove multiple instances of slash commands using `document.querySelector('[id^="tippy"]')`.
1.2. Replacement of blank spaces with `&nbsp;`. 
2. Iframe did not persist when toggled between markdown mode and rich text mode. Updated code to permit `iframe` tags.
3. Class to highlight focussed emoji was deleted during cleanup of styles. Added it back.

Demo: https://vimeo.com/685476970/c2c51dd363

@labeebklatif _a please review.
cc: @karthiknmenon 
