### PR TITLE
Allowed EditorContent links to open in a new tab

### DIFF
--- a/lib/components/Editor/EditorContent.js
+++ b/lib/components/Editor/EditorContent.js
@@ -15,7 +15,9 @@ const EditorContent = ({ content = "", className, ...otherProps }) => {
       className={classnames(EDITOR_CONTENT_CLASSNAME, {
         [className]: className,
       })}
-      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(content, { ADD_ATTR: ["target"] }),
+      }}
       data-cy="neeto-editor-content"
       {...otherProps}
     />


### PR DESCRIPTION
Fixes #195 

- Links in `EditorContent` will open in a new tab.

Demo: https://vimeo.com/688246090/f2fefc53c6

@labeebklatif _a please review.