### PR TITLE
Added missing styles to editor content

### DIFF
--- a/lib/styles/editor/_editor-content.scss
+++ b/lib/styles/editor/_editor-content.scss
@@ -87,6 +87,25 @@
     height: 315px;
     margin: auto;
   }
+
+  mark {
+    background: darken($neeto-ui-secondary-green, 10%);
+    border-radius: $neeto-ui-rounded-sm;
+    padding: 0px 4px;
+  }
+
+  [data-variable] {
+    display: inline-flex;
+    color: $neeto-ui-gray-700;
+    background-color: rgba($neeto-ui-gray-200, 0.5);
+    border-radius: $neeto-ui-rounded-sm;
+    line-height: 1;
+    padding: 4px 6px;
+  }
+
+  [data-mention] {
+    opacity: 0.6;
+  }
 }
 
 .neeto-editor-content--hidden {


### PR DESCRIPTION
Fixes #194 

- Added missing styles to editor content.
- Reference: [_editor.scss](https://github.com/bigbinary/neeto-editor-tiptap/blob/master/lib/styles/editor/_editor.scss#L24-L41).

Demo: https://vimeo.com/688249733/a0b249532f

@labeebklatif _a please review.