### PR TITLE
Updated the structure of mentions prop

### DIFF
--- a/example/App.jsx
+++ b/example/App.jsx
@@ -153,13 +153,11 @@ const App = () => {
             "{label: 'Mention 1', key: 'mention1', imageUrl: 'optional_image_url.jpg'}"
           }
         </HighlightText>{" "}
-        or items can be just plain text like{" "}
-        <HighlightText>'Mention1'</HighlightText>. The available mention
-        suggestions are shown in editor when user types a{" "}
-        <HighlightText>@</HighlightText> character within editor content. The
-        avatar image in the mention suggestion list is enabled by providing
-        truthy value to the <HighlightText>showImageInMention</HighlightText>{" "}
-        prop.
+        . Here the key prop is optional. The available mention suggestions are
+        shown in editor when user types a <HighlightText>@</HighlightText>{" "}
+        character within editor content. The avatar image in the mention
+        suggestion list is enabled by providing truthy value to the{" "}
+        <HighlightText>showImageInMention</HighlightText> prop.
       </Description>
       <div className="flex">
         <CodeBlock>{STRINGS.mentionsSampleCode}</CodeBlock>

--- a/example/App.jsx
+++ b/example/App.jsx
@@ -156,7 +156,7 @@ const App = () => {
         . Here the key prop is optional. The available mention suggestions are
         shown in editor when user types a <HighlightText>@</HighlightText>{" "}
         character within editor content. The avatar image in the mention
-        suggestion list is enabled by providing truthy value to the{" "}
+        suggestion list is enabled by providing a truthy value to the{" "}
         <HighlightText>showImageInMention</HighlightText> prop.
       </Description>
       <div className="flex">

--- a/example/App.jsx
+++ b/example/App.jsx
@@ -150,7 +150,7 @@ const App = () => {
         items of shape{" "}
         <HighlightText>
           {
-            "{label: 'Mention 1', key: 'mention1', imageUrl: 'optional_image_url.jpg'}"
+            "{name: 'Mention 1', key: 'mention1', imageUrl: 'optional_image_url.jpg'}"
           }
         </HighlightText>{" "}
         . Here the key prop is optional. The available mention suggestions are

--- a/example/constants.js
+++ b/example/constants.js
@@ -42,12 +42,12 @@ export const SAMPLE_VARIABLES = [
 
 export const SAMPLE_MENTIONS = [
   {
-    label: "Oliver Smith",
+    name: "Oliver Smith",
     key: "oliver-smith",
     imageUrl: "https://i.pravatar.cc/300",
   },
   {
-    label: "Eve Smith",
+    name: "Eve Smith",
     key: "eve-smith",
     imageUrl: "https://i.pravatar.cc/300",
   },
@@ -113,7 +113,7 @@ export const EDITOR_PROP_TABLE_ROWS = [
   [
     "mentions",
     "Accepts an array of mention suggestions.",
-    `[{ label: "Oliver Smith", key: "oliver-smith" }]`,
+    `[{ name: "Oliver Smith", key: "oliver-smith" }]`,
   ],
   [
     "showImageInMention",
@@ -293,12 +293,12 @@ export const STRINGS = {
   mentionsSampleCode: `
   const mentions = [
     {
-      label: "Oliver Smith",
+      name: "Oliver Smith",
       key: "oliver-smith",
       imageUrl: "https://i.pravatar.cc/300"
     },
     {
-      label: "Eve Smith",
+      name: "Eve Smith",
       key: "eve-smith",
       imageUrl: "https://i.pravatar.cc/300",
     },

--- a/example/constants.js
+++ b/example/constants.js
@@ -46,7 +46,11 @@ export const SAMPLE_MENTIONS = [
     key: "oliver-smith",
     imageUrl: "https://i.pravatar.cc/300",
   },
-  "Jaden Smith",
+  {
+    label: "Eve Smith",
+    key: "eve-smith",
+    imageUrl: "https://i.pravatar.cc/300",
+  },
 ];
 
 export const EDITOR_PROP_TABLE_COLUMNS = [
@@ -293,7 +297,11 @@ export const STRINGS = {
       key: "oliver-smith",
       imageUrl: "https://i.pravatar.cc/300"
     },
-    "Jaden Smith",
+    {
+      label: "Eve Smith",
+      key: "eve-smith",
+      imageUrl: "https://i.pravatar.cc/300",
+    },
   ]
 
   <Editor mentions={mentions} showImageInMention />`,

--- a/lib/components/Editor/CustomExtensions/Mention/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Mention/ExtensionConfig.js
@@ -60,7 +60,7 @@ const Mentions = Mention.extend({
   addCommands() {
     return {
       setMention:
-        (label) =>
+        (name) =>
         ({ chain }) => {
           chain()
             .focus()
@@ -68,8 +68,8 @@ const Mentions = Mention.extend({
               {
                 type: this.name,
                 attrs: {
-                  id: label,
-                  label: label,
+                  id: name,
+                  label: name,
                 },
               },
               {

--- a/lib/components/Editor/CustomExtensions/Mention/MentionList.js
+++ b/lib/components/Editor/CustomExtensions/Mention/MentionList.js
@@ -29,7 +29,7 @@ export class MentionList extends React.Component {
     const item = items[index];
 
     if (item) {
-      command({ label: item.label, id: item.key });
+      command({ label: item.name, id: item.key });
     }
   };
 
@@ -94,18 +94,18 @@ export class MentionList extends React.Component {
         className="neeto-editor-mentions__wrapper"
         data-cy="neeto-editor-mention-list"
       >
-        {items.map(({ label, imageUrl, showImage }, index) => (
+        {items.map(({ key, name, imageUrl, showImage }, index) => (
           <button
             className={classNames("neeto-editor-mentions__item", {
               active: index === selectedIndex,
             })}
-            key={label}
+            key={key}
             onClick={() => this.selectItem(index)}
             type="button"
-            data-cy={`neeto-editor-mention-list-${label}`}
+            data-cy={`neeto-editor-mention-list-${name}`}
           >
-            {showImage && <Avatar user={{ name: label, imageUrl }} />}
-            <p>{label}</p>
+            {showImage && <Avatar user={{ name, imageUrl }} />}
+            <p>{name}</p>
           </button>
         ))}
       </div>

--- a/lib/components/Editor/CustomExtensions/Mention/helpers.js
+++ b/lib/components/Editor/CustomExtensions/Mention/helpers.js
@@ -7,13 +7,13 @@ export const createMentionSuggestions = (
   const mentions = items
     .map((item, index) => ({
       showImage,
-      key: `${hyphenize(item.label)}-${index}`,
+      key: `${hyphenize(item.name)}-${index}`,
       ...item,
     }))
-    .sort((mention1, mention2) => mention1.label.localeCompare(mention2.name));
+    .sort((mention1, mention2) => mention1.name.localeCompare(mention2.name));
 
   return ({ query }) =>
-    mentions.filter((mention) =>
-      mention.label.toLowerCase().includes(query.toLowerCase())
+    mentions.filter(({ name }) =>
+      name.toLowerCase().includes(query.toLowerCase())
     );
 };

--- a/lib/components/Editor/CustomExtensions/Mention/helpers.js
+++ b/lib/components/Editor/CustomExtensions/Mention/helpers.js
@@ -1,21 +1,19 @@
+import { hyphenize } from "utils/common";
+
 export const createMentionSuggestions = (
   items = [],
   { showImage = false } = {}
 ) => {
-  const allSuggestions = items.map((item) => {
-    let suggestionObj;
-    if (typeof item === "string") {
-      suggestionObj = { key: item, label: item };
-    } else if (typeof item === "object") {
-      suggestionObj = { ...item };
-    }
-    suggestionObj.showImage = showImage;
-
-    return suggestionObj;
-  });
+  const mentions = items
+    .map((item, index) => ({
+      showImage,
+      key: `${hyphenize(item.label)}-${index}`,
+      ...item,
+    }))
+    .sort((mention1, mention2) => mention1.label.localeCompare(mention2.name));
 
   return ({ query }) =>
-    allSuggestions.filter((suggestion) =>
-      suggestion.label.toLowerCase().includes(query.toLowerCase())
+    mentions.filter((mention) =>
+      mention.label.toLowerCase().includes(query.toLowerCase())
     );
 };

--- a/lib/components/Editor/CustomExtensions/Mention/index.js
+++ b/lib/components/Editor/CustomExtensions/Mention/index.js
@@ -29,27 +29,22 @@ const Mentions = ({ editor, mentions, showImageInMention }) => {
       )}
     >
       <div className="neeto-editor-mentions__wrapper neeto-editor-mentions__wrapper--small">
-        {mentions.map((item) => {
-          const label = typeof item === "string" ? item : item.label;
-          const imageUrl = typeof item === "string" ? "" : item.imageUrl;
-
-          return (
-            <button
-              className={
-                "neeto-editor-mentions__item neeto-editor-mentions__item--light"
-              }
-              key={label}
-              onClick={() => editor.commands.setMention(label)}
-              type="button"
-              data-cy={`neeto-editor-mention-option-${item.label}`}
-            >
-              {showImageInMention && (
-                <Avatar size="small" user={{ name: label, imageUrl }} />
-              )}
-              <p>{label}</p>
-            </button>
-          );
-        })}
+        {mentions.map(({ key, name, imageUrl }) => (
+          <button
+            className={
+              "neeto-editor-mentions__item neeto-editor-mentions__item--light"
+            }
+            key={key}
+            onClick={() => editor.commands.setMention(name)}
+            type="button"
+            data-cy={`neeto-editor-mention-option-${key}`}
+          >
+            {showImageInMention && (
+              <Avatar size="small" user={{ name, imageUrl }} />
+            )}
+            <p>{name}</p>
+          </button>
+        ))}
       </div>
     </Dropdown>
   );

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -83,18 +83,9 @@ export default function useCustomExtensions({
     customExtensions.push(
       Mention.configure({
         suggestion: {
-          items: createMentionSuggestions(
-            mentions.sort((mention1, mention2) => {
-              const name1 =
-                typeof mention1 === "string" ? mention1 : mention1.label;
-              const name2 =
-                typeof mention2 === "string" ? mention2 : mention2.label;
-              return name1.localeCompare(name2);
-            }),
-            {
-              showImage: showImageInMention,
-            }
-          ),
+          items: createMentionSuggestions(mentions, {
+            showImage: showImageInMention,
+          }),
         },
       })
     );


### PR DESCRIPTION
Fixes #149

- Updated the structure of `mentions` prop as follows:
```js
Array<{key: string, name: string, imageUrl: string}>
```
- Here the `key` prop is optional. The default value of key is `hyphenised-label-index`. If provided, this value will be overridden.
