### PR TITLE
Fixed page scroll issue in markdown mode

### DIFF
--- a/lib/components/Editor/CustomExtensions/Image/LocalUploader.js
+++ b/lib/components/Editor/CustomExtensions/Image/LocalUploader.js
@@ -11,7 +11,6 @@ const DEFAULT_ENDPOINT = "/api/v1/direct_uploads/image_upload";
 const UPPY_CONFIG = {
   allowMultipleUploads: false,
   autoProceed: true,
-  debug: true,
 };
 
 const UPPY_UPLOAD_CONFIG = { formData: true, fieldName: "blob" };

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -5,8 +5,6 @@ import { markdownToHtml } from "utils/markdown";
 
 import useMarkdownMode from "./useMarkdownMode";
 
-import { getMarkdownStyles } from "../../helpers";
-
 const MarkdownEditor = ({
   editor,
   className,
@@ -17,12 +15,13 @@ const MarkdownEditor = ({
   initialValue,
   ...otherProps
 }) => {
-  const { textareaRef, content, setContent } = useMarkdownMode({
+  const { textareaRef, content, setContent, markdownStyles } = useMarkdownMode({
     editor,
+    style,
+    strategy,
     onSubmit,
     initialValue,
   });
-  const markdownStyles = getMarkdownStyles({ strategy, style, textareaRef });
 
   const handleChange = (e) => {
     setContent(e.target.value);

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -1,7 +1,9 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React from "react";
 import classNames from "classnames";
 
-import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
+import { markdownToHtml } from "utils/markdown";
+
+import useMarkdownMode from "./useMarkdownMode";
 
 const MarkdownEditor = ({
   editor,
@@ -13,46 +15,17 @@ const MarkdownEditor = ({
   initialValue,
   ...otherProps
 }) => {
-  const [content, setContent] = useState(() =>
-    htmlToMarkdown(editor?.getHTML() || initialValue)
-  );
-
-  const textareaRef = useRef();
-  const contentRef = useRef(content);
-
-  const BORDER_HEIGHT = 1;
-
-  useEffect(() => {
-    contentRef.current = content;
-  }, [content]);
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleSubmit);
-
-    return () => {
-      editor?.commands.setContent(markdownToHtml(contentRef.current));
-      document.removeEventListener("keydown", handleSubmit);
-    };
-  }, []);
-
-  useLayoutEffect(() => {
-    textareaRef.current.style = style;
-    strategy === "flexible" &&
-      (textareaRef.current.style.height =
-        textareaRef.current.scrollHeight + 2 * BORDER_HEIGHT + "px");
-  }, [content]);
+  const { textareaRef, content, setContent } = useMarkdownMode({
+    editor,
+    style,
+    onSubmit,
+    strategy,
+    initialValue,
+  });
 
   const handleChange = (e) => {
     setContent(e.target.value);
     onChange?.(markdownToHtml(e.target.value));
-  };
-
-  // Submit on Ctrl+Enter and Cmd+Enter
-  const handleSubmit = (e) => {
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-      onSubmit?.(markdownToHtml(contentRef.current));
-      textareaRef.current.blur();
-    }
   };
 
   return (

--- a/lib/components/Editor/CustomExtensions/Markdown/index.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/index.js
@@ -5,6 +5,8 @@ import { markdownToHtml } from "utils/markdown";
 
 import useMarkdownMode from "./useMarkdownMode";
 
+import { getMarkdownStyles } from "../../helpers";
+
 const MarkdownEditor = ({
   editor,
   className,
@@ -17,11 +19,10 @@ const MarkdownEditor = ({
 }) => {
   const { textareaRef, content, setContent } = useMarkdownMode({
     editor,
-    style,
     onSubmit,
-    strategy,
     initialValue,
   });
+  const markdownStyles = getMarkdownStyles({ strategy, style, textareaRef });
 
   const handleChange = (e) => {
     setContent(e.target.value);
@@ -37,6 +38,7 @@ const MarkdownEditor = ({
         [className]: className,
       })}
       data-cy="neeto-editor-markdown-editor"
+      style={markdownStyles}
       {...otherProps}
     />
   );

--- a/lib/components/Editor/CustomExtensions/Markdown/useMarkdownMode.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/useMarkdownMode.js
@@ -1,20 +1,13 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
 
-const useMarkdownMode = ({
-  editor,
-  initialValue,
-  onSubmit,
-  style,
-  strategy,
-}) => {
+const useMarkdownMode = ({ editor, initialValue, onSubmit }) => {
   const [content, setContent] = useState(() =>
     htmlToMarkdown(editor?.getHTML() || initialValue)
   );
   const textareaRef = useRef();
   const contentRef = useRef(content);
-  const BORDER_HEIGHT = 1;
 
   // Submit on Ctrl+Enter and Cmd+Enter
   const handleSubmit = (e) => {
@@ -34,14 +27,6 @@ const useMarkdownMode = ({
 
   useEffect(() => {
     contentRef.current = content;
-  }, [content]);
-
-  // Auto resize textarea on content change
-  useLayoutEffect(() => {
-    textareaRef.current.style = style;
-    strategy === "flexible" &&
-      (textareaRef.current.style.height =
-        textareaRef.current.scrollHeight + 2 * BORDER_HEIGHT + "px");
   }, [content]);
 
   return { textareaRef, content, setContent };

--- a/lib/components/Editor/CustomExtensions/Markdown/useMarkdownMode.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/useMarkdownMode.js
@@ -1,0 +1,50 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
+
+const useMarkdownMode = ({
+  editor,
+  initialValue,
+  onSubmit,
+  style,
+  strategy,
+}) => {
+  const [content, setContent] = useState(() =>
+    htmlToMarkdown(editor?.getHTML() || initialValue)
+  );
+  const textareaRef = useRef();
+  const contentRef = useRef(content);
+  const BORDER_HEIGHT = 1;
+
+  // Submit on Ctrl+Enter and Cmd+Enter
+  const handleSubmit = (e) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      onSubmit?.(markdownToHtml(contentRef.current));
+      textareaRef.current.blur();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleSubmit);
+    return () => {
+      editor?.commands.setContent(markdownToHtml(contentRef.current));
+      document.removeEventListener("keydown", handleSubmit);
+    };
+  }, []);
+
+  useEffect(() => {
+    contentRef.current = content;
+  }, [content]);
+
+  // Auto resize textarea on content change
+  useLayoutEffect(() => {
+    textareaRef.current.style = style;
+    strategy === "flexible" &&
+      (textareaRef.current.style.height =
+        textareaRef.current.scrollHeight + 2 * BORDER_HEIGHT + "px");
+  }, [content]);
+
+  return { textareaRef, content, setContent };
+};
+
+export default useMarkdownMode;

--- a/lib/components/Editor/CustomExtensions/Markdown/useMarkdownMode.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/useMarkdownMode.js
@@ -2,7 +2,16 @@ import { useEffect, useRef, useState } from "react";
 
 import { htmlToMarkdown, markdownToHtml } from "utils/markdown";
 
-const useMarkdownMode = ({ editor, initialValue, onSubmit }) => {
+import { getMarkdownStyles } from "../../helpers";
+
+const useMarkdownMode = ({
+  editor,
+  initialValue,
+  onSubmit,
+  strategy,
+  style,
+}) => {
+  const [markdownStyles, setMarkdownStyles] = useState({});
   const [content, setContent] = useState(() =>
     htmlToMarkdown(editor?.getHTML() || initialValue)
   );
@@ -27,9 +36,10 @@ const useMarkdownMode = ({ editor, initialValue, onSubmit }) => {
 
   useEffect(() => {
     contentRef.current = content;
+    setMarkdownStyles(getMarkdownStyles({ strategy, style, textareaRef }));
   }, [content]);
 
-  return { textareaRef, content, setContent };
+  return { textareaRef, content, setContent, markdownStyles };
 };
 
 export default useMarkdownMode;

--- a/lib/components/Editor/helpers.js
+++ b/lib/components/Editor/helpers.js
@@ -1,4 +1,3 @@
-import { stringifyObject } from "utils/common";
 import {
   EDITOR_PADDING_SIZE,
   EDITOR_LINE_HEIGHT,
@@ -24,7 +23,18 @@ export const getEditorStyles = ({ heightStrategy, rows }) => {
     rows * EDITOR_LINE_HEIGHT + 2 * (EDITOR_PADDING_SIZE + EDITOR_BORDER_SIZE);
   if (heightStrategy === "flexible") styles["min-height"] = editorHeight + "px";
   else styles.height = editorHeight + "px";
-  return stringifyObject(styles);
+  return styles;
+};
+
+export const getMarkdownStyles = ({ strategy, style, textareaRef }) => {
+  const styles = { ...style };
+  if (styles["min-height"]) {
+    styles.height = styles["min-height"];
+    delete styles["min-height"];
+  }
+  if (strategy === "flexible" && textareaRef.current)
+    styles.minHeight = textareaRef.current?.scrollHeight;
+  return styles;
 };
 
 export const generateAddonOptions = (addons = [], { includeImageUpload }) => {

--- a/lib/components/Editor/helpers.js
+++ b/lib/components/Editor/helpers.js
@@ -33,7 +33,7 @@ export const getMarkdownStyles = ({ strategy, style, textareaRef }) => {
     delete styles["min-height"];
   }
   if (strategy === "flexible" && textareaRef.current)
-    styles.minHeight = textareaRef.current?.scrollHeight;
+    styles.height = textareaRef.current?.scrollHeight;
   return styles;
 };
 

--- a/lib/components/Editor/helpers.js
+++ b/lib/components/Editor/helpers.js
@@ -29,7 +29,7 @@ export const getEditorStyles = ({ heightStrategy, rows }) => {
 export const getMarkdownStyles = ({ strategy, style, textareaRef }) => {
   const styles = { ...style };
   if (styles["min-height"]) {
-    styles.height = styles["min-height"];
+    styles.minHeight = styles["min-height"];
     delete styles["min-height"];
   }
   if (strategy === "flexible" && textareaRef.current)

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import { useEditor, EditorContent } from "@tiptap/react";
+import { stringifyObject } from "utils/common";
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
 import ImageUploader from "./CustomExtensions/Image/Uploader";
@@ -93,7 +94,7 @@ const Editor = (
     editorProps: {
       attributes: {
         class: editorClasses,
-        style: editorStyles,
+        style: stringifyObject(editorStyles),
       },
     },
     onUpdate: ({ editor }) => onChange(editor.getHTML()),


### PR DESCRIPTION
Fixes #203 
- Fixed the issue where the page scrolls to the end of cursor position whenever the user types a large content in markdown mode.

Demo: https://vimeo.com/688818127/d11262704b
Gist: https://gist.github.com/AbhayVAshokan/850dc525b3fa5801de13a2c3744f7532

@labeebklatif _a please review.