### PR TITLE
Added the missing onSubmit prop to the useCustomExtensions hook

### DIFF
--- a/example/constants.js
+++ b/example/constants.js
@@ -377,7 +377,7 @@ export const STRINGS = {
     }
 
     const keyboardShortcuts = {
-      "Shift-Enter": (editor) => {
+      "Shift-Enter": ({ editor }) => {
         alert(editor.getHTML());
         return true;
       },

--- a/lib/components/Editor/CustomExtensions/Markdown/useMarkdownEditor.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/useMarkdownEditor.js
@@ -45,9 +45,11 @@ const useMarkdownEditor = ({ content, onUpdate, onSubmit, markdownMode }) => {
   // Submit on Ctrl+Enter and Cmd+Enter
   const handleSubmit = useCallback(
     (e) => {
+      if (!markdownMode) return;
       if (e.key !== "Enter" || !(e.metaKey || e.ctrlKey)) return;
+
       inputFieldRef.current?.blur();
-      if (!markdownMode || !onSubmit) return;
+      if (!onSubmit) return;
       const htmlContent = getHTML();
       onSubmit({ markdown: editorContentRef.current, html: htmlContent });
     },

--- a/lib/components/Editor/CustomExtensions/Markdown/useMarkdownEditor.js
+++ b/lib/components/Editor/CustomExtensions/Markdown/useMarkdownEditor.js
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect, useCallback, useMemo } from "react";
 
 import { htmlToMarkdown, markdownToHtml, htmlToText } from "utils/markdown";
 
-const useMarkdownEditor = ({ content, onUpdate, onSubmit }) => {
+const useMarkdownEditor = ({ content, onUpdate, onSubmit, markdownMode }) => {
   const [editorState, setEditorState] = useState(() => {
     if (!content) return { content: "", length: 0 };
     const markdownContent = htmlToMarkdown(content);
@@ -47,11 +47,11 @@ const useMarkdownEditor = ({ content, onUpdate, onSubmit }) => {
     (e) => {
       if (e.key !== "Enter" || !(e.metaKey || e.ctrlKey)) return;
       inputFieldRef.current?.blur();
-      if (!onSubmit) return;
+      if (!markdownMode || !onSubmit) return;
       const htmlContent = getHTML();
       onSubmit({ markdown: editorContentRef.current, html: htmlContent });
     },
-    [editorContentRef]
+    [editorContentRef, markdownMode]
   );
 
   // subscribe to onSubmit handlers

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -81,6 +81,7 @@ const Editor = (
     addonCommands,
     characterLimit,
     keyboardShortcuts,
+    onSubmit,
   });
 
   const editorClasses = classNames("neeto-editor", {
@@ -115,6 +116,7 @@ const Editor = (
     content: initialValue,
     onUpdate: ({ html }) => onChange(html),
     onSubmit: ({ html }) => onSubmit && onSubmit(html),
+    markdownMode,
   });
 
   /* Make editor object available to the parent */


### PR DESCRIPTION
Fixes #217
- Properly passed the prop for `onSubmit` method to the `useCustomExtensions` hook.
- Updated documentation for keyboard shortcuts.

@labeebklatif _a please review.