### PR TITLE
Added custom clipboardTextParser method

### DIFF
--- a/lib/components/Editor/helpers.js
+++ b/lib/components/Editor/helpers.js
@@ -1,3 +1,5 @@
+import { Slice, Fragment, Node } from "prosemirror-model";
+
 import {
   EDITOR_PADDING_SIZE,
   EDITOR_LINE_HEIGHT,
@@ -30,4 +32,21 @@ export const generateAddonOptions = (addons = [], { includeImageUpload }) => {
   const userAddonOptions = addons.map((option) => option.toLowerCase());
   if (includeImageUpload) userAddonOptions.push(ADD_ON_OPTIONS.IMAGE_UPLOAD);
   return [].concat(DEFAULT_ADD_ON_OPTIONS, userAddonOptions);
+};
+
+export const clipboardTextParser = (text, context) => {
+  const nodes = [];
+  const blocks = text.split(/\n/);
+
+  blocks.forEach((line) => {
+    const nodeJson = { type: "paragraph" };
+    if (line.length > 0) {
+      nodeJson.content = [{ type: "text", text: line }];
+    }
+    const node = Node.fromJSON(context.doc.type.schema, nodeJson);
+    nodes.push(node);
+  });
+
+  const fragment = Fragment.fromArray(nodes);
+  return Slice.maxOpen(fragment);
 };

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -16,6 +16,7 @@ import {
   generateAddonOptions,
   getEditorStyles,
   getIsPlaceholderActive,
+  clipboardTextParser,
 } from "./helpers";
 
 const Editor = (
@@ -107,6 +108,7 @@ const Editor = (
         class: editorClasses,
         style: stringifyObject(editorStyles),
       },
+      clipboardTextParser,
     },
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
     onFocus,


### PR DESCRIPTION
Fixes #224 
- Added logic to preserve new lines while pasting textual content.

Demo: https://vimeo.com/704524081/1eec603e86

@labeebklatif _a please review.  Also, please try out different pasting options just to make sure it does not have any unnecessary behavior while overriding Prosemirror default behavior.