### PR TITLE
Removed the Typography extension

### DIFF
--- a/lib/components/Editor/CustomExtensions/Typography/EditorConfig.js
+++ b/lib/components/Editor/CustomExtensions/Typography/EditorConfig.js
@@ -1,0 +1,12 @@
+import Typography from "@tiptap/extension-typography";
+
+export default Typography.configure({
+  emDash: false,
+  openDoubleQuote: false,
+  closeDoubleQuote: false,
+  openSingleQuote: false,
+  closeSingleQuote: false,
+  leftArrow: false,
+  rightArrow: false,
+  multiplication: false,
+});

--- a/lib/components/Editor/CustomExtensions/Typography/EditorConfig.js
+++ b/lib/components/Editor/CustomExtensions/Typography/EditorConfig.js
@@ -6,7 +6,4 @@ export default Typography.configure({
   closeDoubleQuote: false,
   openSingleQuote: false,
   closeSingleQuote: false,
-  leftArrow: false,
-  rightArrow: false,
-  multiplication: false,
 });

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -1,5 +1,4 @@
 import StarterKit from "@tiptap/starter-kit";
-import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
 import Dropcursor from "@tiptap/extension-dropcursor";
 import CharacterCount from "@tiptap/extension-character-count";
@@ -49,7 +48,6 @@ export default function useCustomExtensions({
       codeBlock: false,
     }),
     Underline,
-    Typography,
     TextStyle,
     Highlight,
     CodeBlock,

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -21,6 +21,7 @@ import Embeds from "./Embeds/ExtensionConfig";
 import EmojiSuggestion from "./Emoji/EmojiSuggestion/ExtensionConfig";
 import EmojiPicker from "./Emoji/EmojiPicker/ExtensionConfig";
 import KeyboardShortcuts from "./KeyboardShortcuts/ExtensionConfig";
+import Typography from "./Typography/EditorConfig";
 import { isNilOrEmpty } from "utils/common";
 
 export default function useCustomExtensions({
@@ -48,6 +49,7 @@ export default function useCustomExtensions({
       codeBlock: false,
     }),
     Underline,
+    Typography,
     TextStyle,
     Highlight,
     CodeBlock,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/extension-mention": "^2.0.0-beta.80",
     "@tiptap/extension-placeholder": "^2.0.0-beta.18",
     "@tiptap/extension-text-style": "^2.0.0-beta.17",
+    "@tiptap/extension-typography": "^2.0.0-beta.20",
     "@tiptap/extension-underline": "^2.0.0-beta.21",
     "@tiptap/react": "^2.0.0-beta.37",
     "@tiptap/starter-kit": "^2.0.0-beta.57",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@tiptap/extension-mention": "^2.0.0-beta.80",
     "@tiptap/extension-placeholder": "^2.0.0-beta.18",
     "@tiptap/extension-text-style": "^2.0.0-beta.17",
-    "@tiptap/extension-typography": "^2.0.0-beta.11",
     "@tiptap/extension-underline": "^2.0.0-beta.21",
     "@tiptap/react": "^2.0.0-beta.37",
     "@tiptap/starter-kit": "^2.0.0-beta.57",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,11 +1982,6 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.0.0-beta.13.tgz#da0af8d9a3f149d20076e15d88c6af21fb6d940f"
   integrity sha512-0EtAwuRldCAoFaL/iXgkRepEeOd55rPg5N4FQUN1xTwZT7PDofukP0DG/2jff/Uj17x4uTaJAa9qlFWuNnDvjw==
 
-"@tiptap/extension-typography@^2.0.0-beta.11":
-  version "2.0.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-typography/-/extension-typography-2.0.0-beta.17.tgz#cc8c317997da580d4771ee2465f552d52fd078af"
-  integrity sha512-w98KiifXdK9I+/vTKap2DJdEGvG72Sg02t93kpzyw5P7pYG0ZzCpFgdF7Vh8+Xp4JqffBayYh81mKEB+rxeu3w==
-
 "@tiptap/extension-underline@^2.0.0-beta.21":
   version "2.0.0-beta.21"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-underline/-/extension-underline-2.0.0-beta.21.tgz#42cda46097da32302366e9deefc50336c5f64bc3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,6 +1982,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.0.0-beta.13.tgz#da0af8d9a3f149d20076e15d88c6af21fb6d940f"
   integrity sha512-0EtAwuRldCAoFaL/iXgkRepEeOd55rPg5N4FQUN1xTwZT7PDofukP0DG/2jff/Uj17x4uTaJAa9qlFWuNnDvjw==
 
+"@tiptap/extension-typography@^2.0.0-beta.20":
+  version "2.0.0-beta.20"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-typography/-/extension-typography-2.0.0-beta.20.tgz#6a721d5222e250aff6d4996acd0f6bc0e183eecc"
+  integrity sha512-rDgl5ssuM/UKTZHHN1QgF5lZTqNI/q7hxpsk7SZhGjuTSbo2mJ38shaKWEsLmofer/xE6+lWtYo8IVkuv998QA==
+
 "@tiptap/extension-underline@^2.0.0-beta.21":
   version "2.0.0-beta.21"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-underline/-/extension-underline-2.0.0-beta.21.tgz#42cda46097da32302366e9deefc50336c5f64bc3"


### PR DESCRIPTION
Fixes #236 
- Removed the `Typography` extension. It was responsible for converting double quotes to a smart font.
- It is also possible to disable specific rules in the `Typography` extension: https://tiptap.dev/api/extensions/typography. But converting to a smart font seems unnecessary.

@amaldinesh7 _a can you please take a look?