### PR TITLE
Use ubuntu-latest for GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Release"
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes #253 

Updated publish the workflow to use ubuntu-latest instead of macos-latest.
@AbhayVAshokan _a