### PR TITLE
Updated data-cy of cancel link button

### DIFF
--- a/lib/components/Editor/CustomExtensions/BubbleMenu/LinkOption.jsx
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/LinkOption.jsx
@@ -58,7 +58,7 @@ const LinkOption = ({ editor, handleClose, handleAnimateInvalidLink }) => {
         style="icon"
         icon={Close}
         onClick={handleReset}
-        data-cy="neeto-editor-link-submit-button"
+        data-cy="neeto-editor-link-cancel-button"
       />
     </div>
   );


### PR DESCRIPTION
Fixes #261 
- Updated the `data-cy` prop of cancel link button from `neeto-editor-link-submit-button` to `neeto-editor-link-cancel-button`.

@AbhayVAshokan _a