### PR TITLE
Added PR template and publish action

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,6 @@ Fixes #issue-number
 
 - [ ] I have performed a self-review of my code.
 - [ ] I have made corresponding changes to the documentation.
-- [ ] I have added tests that prove my fix is effective or that my feature
-      works.
 - [ ] I have added the necessary label (patch/minor/major - If package publish
       is required).
 - [ ] I have followed the suggested description format and styling.
@@ -29,11 +27,5 @@ Points to note:
 - The description shall be represented in bullet points.
 - Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
 - Represent a component name in italics, eg: _Modal_.
-- Enclose a prop name in double backticks, eg: `isLoading`.
-
-Example:
-- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
-- Added: `hideOnTargetExit` prop to _Tooltip_ component.
-- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
-- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
+- Enclose a prop name in double backticks, eg: `menuType`.
 --->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+Fixes #issue-number
+
+**Description**
+
+**Checklist**
+
+- [ ] I have performed a self-review of my code.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added tests that prove my fix is effective or that my feature
+      works.
+- [ ] I have added the necessary label (patch/minor/major - If package publish
+      is required).
+- [ ] I have followed the suggested description format and styling.
+
+**Reviewers**
+
+<!---
+------------- FORMAT FOR DESCRIPTION -------------
+
+Prefix the change with one of these keywords:
+- Added: for new features.
+- Changed: for changes in existing functionality.
+- Deprecated: for soon-to-be removed features.
+- Removed: for now removed features.
+- Fixed: for any bug fixes.
+- Security: in case of vulnerabilities.
+
+Points to note:
+- The description shall be represented in bullet points.
+- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
+- Represent a component name in italics, eg: _Modal_.
+- Enclose a prop name in double backticks, eg: `isLoading`.
+
+Example:
+- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
+- Added: `hideOnTargetExit` prop to _Tooltip_ component.
+- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
+- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
+--->

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,12 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    if:
-      ${{ github.event.pull_request.merged == true &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2.2.0
-      - name: node
+
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: "14"
@@ -23,10 +22,35 @@ jobs:
       - run: yarn config set version-tag-prefix "v"
       - run: git config core.hooksPath /dev/null
 
-      - name: Bump version and create tag
-        if: contains(github.event.pull_request.labels.*.name, 'release')
-        run: yarn version --patch
+      - name: Find version bump type
+        id: BUMP_TYPE
+        run: |
+          IFS=',' read -r -a label_array <<< "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+          for item in ${label_array[*]}
+          do
+            if [[ "$item" == "major" || "$item" == "minor" || "$item" == "patch" ]]; then
+              echo "::set-output name=TYPE::$(echo $item)"
+            fi
+          done
+        shell: bash
 
+      - name: Git tagging check
+        id: TAG_CHECK
+        run: |
+          IFS=',' read -r -a label_array <<< "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+          if [[ "${label_array[*]}" =~ "release" ]]; then
+            echo "::set-output name=TAG_OPTION::"
+          else
+            echo "::set-output name=TAG_OPTION::--no-git-tag-version"
+          fi
+      - name: Bump Version
+        id: BUMP_VERSION
+        run: |
+          BUMP_TYPE=${{steps.BUMP_TYPE.outputs.TYPE}}
+          VERSION_BUMP_TYPE=$([ -z BUMP_TYPE ] && echo "patch" || echo $BUMP_TYPE)
+          yarn version --$VERSION_BUMP_TYPE ${{steps.TAG_CHECK.outputs.TAG_OPTION}}
+          PACKAGE_VERSION=$(cat package.json|grep version|head -1|awk -F: '{ print $2 }'|sed 's/[", ]//g')
+          echo "::set-output name=PACKAGE_VERSION::$(echo $PACKAGE_VERSION)"
       - name: Read pull request body
         uses: 8BitJonny/gh-get-current-pr@2.0.0
         id: PR
@@ -47,33 +71,22 @@ jobs:
           latest-version: ${{ steps.BUMP_VERSION.outputs.PACKAGE_VERSION }}
           release-notes: ${{ fromJson(env.CHANGELOG) }}
 
-      - name: Bump version
-        if: "!contains(github.event.pull_request.labels.*.name, 'release')"
-        run: yarn version --patch --no-git-tag-version
-
-      - uses: EndBug/add-and-commit@v7
+      - name: Commit and Push changes
+        uses: EndBug/add-and-commit@v7
         with:
           branch: master
-          message: "New version release"
+          message: 'New version release'
 
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read package.json
-        uses: tyankatsu0105/read-package-version-actions@v1
-        id: package-version
-
-      - name: Release Drafter
+      - name: Create Github Release
         uses: release-drafter/release-drafter@v5.15.0
         if: ${{contains(github.event.pull_request.labels.*.name, 'release')}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: v${{ steps.package-version.outputs.version }}
+          tag: v${{ steps.BUMP_VERSION.outputs.VERSION }}
           publish: true
-      - name: "Publish"
+
+      - name: "Publish to NPM"
         uses: JS-DevTools/npm-publish@v1
         with:
           access: "public"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,26 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'release')
         run: yarn version --patch
 
+      - name: Read pull request body
+        uses: 8BitJonny/gh-get-current-pr@2.0.0
+        id: PR
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ github.event.pull_request.head.sha }}
+
+      - name: Extract changelog
+        id: CHANGELOG
+        run: |
+           content=$(echo '${{ steps.PR.outputs.pr_body }}' | python3 -c 'import json; import sys; print(json.dumps(sys.stdin.read().partition("**Description**")[2].partition("**Checklist**")[0].strip()))')
+           echo "CHANGELOG=${content}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ steps.BUMP_VERSION.outputs.PACKAGE_VERSION }}
+          release-notes: ${{ fromJson(env.CHANGELOG) }}
+
       - name: Bump version
         if: "!contains(github.event.pull_request.labels.*.name, 'release')"
         run: yarn version --patch --no-git-tag-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ------ FOLLOW THESE WHILE ADDING AN ENTRY ------
 
 ** Add BREAKING keyword in bold for changes which could potentially break the component, eg: **BREAKING**.
-** Represent a component name in italics, eg: _Modal_.
-** Enclose a prop name in double backticks, eg: `isLoading`.
+** Enclose a prop name in double backticks, eg: `menuType`.
 ** Represent a version as second level heading and write the version number inside a square bracket, eg: ##  [3.3.2].
 
 --->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ------ FOLLOW THESE WHILE ADDING AN ENTRY ------
 
-** Add BREAKING keyword in bold for changes which could potentially break the component, eg: **BREAKING**
-** Enclose a prop name in double backticks, eg: `isLoading`
+** Add BREAKING keyword in bold for changes which could potentially break the component, eg: **BREAKING**.
+** Represent a component name in italics, eg: _Modal_.
+** Enclose a prop name in double backticks, eg: `isLoading`.
+** Represent a version as second level heading and write the version number inside a square bracket, eg: ##  [3.3.2].
 
 --->
 
@@ -15,9 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Prefix the change with one of these keywords:
 
-- _Added_ : for new features.
-- _Changed_ : for changes in existing functionality.
-- _Deprecated_ : for soon-to-be removed features.
-- _Removed_ : for now removed features.
-- _Fixed_ : for any bug fixes.
-- _Security_ : in case of vulnerabilities.
+- _Added_: for new features.
+- _Changed_: for changes in existing functionality.
+- _Deprecated_: for soon-to-be removed features.
+- _Removed_: for now removed features.
+- _Fixed_: for any bug fixes.
+- _Security_: in case of vulnerabilities.


### PR DESCRIPTION
Fixes #285 

- Added PR template.
- Synced CHANGELOG.md file with neetoUI.
- Synced `.github/workflows/publish.yml` workflows with neetoUI.

@amaldinesh7 _a please have a look. The PR template mentions about adding necessary labels. This practice has not been followed in neetoEditor. Hence, do check if the necessary changes for the same are added. I am not sure what the functionality of `enforce-label.yml` file is, so haven't added the same.