### PR TITLE
Prevent placeholder from overlapping image

### DIFF
--- a/lib/styles/editor/_editor.scss
+++ b/lib/styles/editor/_editor.scss
@@ -59,6 +59,10 @@
     position: relative;
   }
 
+  [data-placeholder].is-empty:last-child::before {
+    left: auto !important;
+  }
+
   &.placeholder-active {
     &:not(.force-title) {
       .is-editor-empty:first-child::before {


### PR DESCRIPTION
Fixes #283 

**Description**

- Fixed:  the overlap of placeholder with images.

**Checklist**

- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@amaldinesh7 _a
This PR can be used to test the Changelog workflow as well as the Netlify deployment issue.

Demo: https://vimeo.com/732005994/a2065af352



<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
