### PR TITLE
Added addon to paste content without formatting

### DIFF
--- a/lib/components/Editor/CustomExtensions/CustomCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/CustomCommands/ExtensionConfig.js
@@ -1,0 +1,16 @@
+import { Extension } from "@tiptap/core";
+
+export default Extension.create({
+  name: "paste-unformatted",
+
+  addCommands() {
+    return {
+      pasteUnformatted:
+        () =>
+        async ({ editor }) => {
+          const text = await navigator.clipboard.readText();
+          editor.commands.insertContent(text);
+        },
+    };
+  },
+});

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -38,6 +38,7 @@ export default {
       MENU_ITEMS.EMOJI,
       MENU_ITEMS.DIVIDER,
       MENU_ITEMS.VIDEO,
+      MENU_ITEMS.PASTE_UNFORMATTED,
     ];
 
     if (!isNilOrEmpty(allowedCommandOptions)) {

--- a/lib/components/Editor/CustomExtensions/SlashCommands/constants.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/constants.js
@@ -206,16 +206,8 @@ export const MENU_ITEMS = {
     title: "Paste Unformatted",
     description: "Paste by removing all styles.",
     Icon: Notes,
-    command: async ({ editor, range }) => {
-      const text = await navigator.clipboard.readText();
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertContent(text)
-        .insertContent("\n")
-        .run();
-    },
+    command: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).pasteUnformatted().run(),
   },
 
   // placeholder item when no matching results found

--- a/lib/components/Editor/CustomExtensions/SlashCommands/constants.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/constants.js
@@ -13,6 +13,7 @@ import {
   Minus,
   Video,
   Text,
+  Notes,
 } from "neetoicons";
 import { validateYouTubeUrl, validateVimeoUrl } from "utils/embeds";
 
@@ -198,6 +199,22 @@ export const MENU_ITEMS = {
           .insertContent("#invalid")
           .run();
       }
+    },
+  },
+  PASTE_UNFORMATTED: {
+    optionName: EDITOR_OPTIONS.PASTE_UNFORMATTED,
+    title: "Paste Unformatted",
+    description: "Paste by removing all styles.",
+    Icon: Notes,
+    command: async ({ editor, range }) => {
+      const text = await navigator.clipboard.readText();
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent(text)
+        .insertContent("\n")
+        .run();
     },
   },
 

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -9,6 +9,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { isNilOrEmpty } from "utils/common";
 
 import CodeBlock from "./CodeBlock/ExtensionConfig";
+import CustomCommands from "./CustomCommands/ExtensionConfig";
 import Document from "./Document/ExtensionConfig";
 import Embeds from "./Embeds/ExtensionConfig";
 import EmojiPicker from "./Emoji/EmojiPicker/ExtensionConfig";
@@ -63,6 +64,7 @@ const useCustomExtensions = ({
     }),
     EmojiSuggestion,
     EmojiPicker,
+    CustomCommands,
     CharacterCount.configure({
       limit: characterLimit,
     }),

--- a/lib/constants/common.js
+++ b/lib/constants/common.js
@@ -31,6 +31,7 @@ export const EDITOR_OPTIONS = {
   IMAGE_UPLOAD_UNSPLASH: "image-upload-unsplash",
   DIVIDER: "divider",
   VIDEO_EMBED: "video-embed",
+  PASTE_UNFORMATTED: "paste-unformatted",
 
   // OTHER AVAILABLE OPTIONS
   H3: "h3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-transform-runtime": "^7.16.5",
     "@babel/preset-env": "^7.13.15",
     "@babel/preset-react": "^7.13.13",
-    "@bigbinary/neeto-icons": "^1.8.25",
+    "@bigbinary/neeto-icons": "^1.8.37",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -123,7 +123,7 @@ export const EDITOR_PROP_TABLE_ROWS = [
   [
     "addons",
     "Accepts an array of strings, each corresponding to the name of an addon.",
-    `["highlight", "emoji", "code-block", "block-quote", "image-upload", "divider", "video-embed"]`,
+    `["highlight", "emoji", "code-block", "block-quote", "image-upload", "divider", "video-embed", "paste-unformatted"]`,
   ],
   [
     "defaults",

--- a/stories/Examples/Customize-options/Addons.stories.mdx
+++ b/stories/Examples/Customize-options/Addons.stories.mdx
@@ -35,6 +35,7 @@ prop. Customize default options
         "image-upload",
         "image-upload-unsplash",
         "video-embed",
+        "paste-unformatted",
       ]}
     />
   </Story>

--- a/stories/constants.js
+++ b/stories/constants.js
@@ -9,6 +9,7 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
   ["image-upload-unsplash", "Add unsplash integration to the image upload."],
   ["divider", "Add a horizontal line to separate different sections."],
   ["video-embed", "Embed videos from YouTube and Vimeo."],
+  ["paste-unformatted", "Paste by removing all styles."],
 ];
 
 export const EDITOR_PROP_TABLE_COLUMNS = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,7 +1210,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bigbinary/neeto-icons@^1.8.25":
+"@bigbinary/neeto-icons@^1.8.37":
   version "1.8.37"
   resolved "https://registry.yarnpkg.com/@bigbinary/neeto-icons/-/neeto-icons-1.8.37.tgz#15b42abc64620ad2384574b55ab63b8acac02427"
   integrity sha512-VRDZpyFPDoCaLTfj9LFI8DmqAJ0VX1r3K5HFJ6Se+v56Cqf0fqpsqmRUrH3K/NuG4vdSDHRVDJz5PVe8hA0YLA==


### PR DESCRIPTION
Fixes #279 

**Description**
- Added `paste-unformatted` addon in the slash commands. It removes all the HTML formatting while pasting.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@labeebklatif _a please review.
Demo: https://vimeo.com/732091688/f4eb0b2945

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
