### PR TITLE
Click image on EditorContent to open it in a new tab

### DIFF
--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -65,8 +65,14 @@ export default Image.extend({
     const wrapperClass = `neeto-editor__image neeto-editor__image--${float} neeto-editor__image--${align}`;
 
     return [
-      "div",
-      { class: wrapperClass, style: wrapperStyles },
+      "a",
+      {
+        class: wrapperClass,
+        style: wrapperStyles,
+        href: src,
+        target: "_blank",
+        rel: "noopener noreferrer",
+      },
       ["figure", {}, ["img", { src, caption }], ["figcaption", caption]],
     ];
   },


### PR DESCRIPTION
Fixes #302

**Description**

- Added the ability to open images in _EditorContent_ in a new tab using a single click.

**Checklist**

- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
