### PR TITLE
Insert variables at end of existing content

### DIFF
--- a/lib/components/Editor/helpers.js
+++ b/lib/components/Editor/helpers.js
@@ -6,6 +6,7 @@ import {
 import { EDITOR_OPTIONS } from "constants/common";
 
 import { Slice, Fragment, Node } from "prosemirror-model";
+import { Selection } from "prosemirror-state";
 
 export const getIsPlaceholderActive = placeholder => {
   if (placeholder) {
@@ -57,4 +58,12 @@ export const clipboardTextParser = (text, context) => {
 
   const fragment = Fragment.fromArray(nodes);
   return Slice.maxOpen(fragment);
+};
+
+export const setInitialPosition = editor => {
+  const { state, view } = editor;
+  const endPosition = Selection.atEnd(state.doc);
+  const transation = state.tr;
+  transation.setSelection(endPosition);
+  view.dispatch(transation);
 };

--- a/lib/components/Editor/helpers.js
+++ b/lib/components/Editor/helpers.js
@@ -63,7 +63,7 @@ export const clipboardTextParser = (text, context) => {
 export const setInitialPosition = editor => {
   const { state, view } = editor;
   const endPosition = Selection.atEnd(state.doc);
-  const transation = state.tr;
-  transation.setSelection(endPosition);
-  view.dispatch(transation);
+  const transaction = state.tr;
+  transaction.setSelection(endPosition);
+  view.dispatch(transaction);
 };

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -102,7 +102,7 @@ const Editor = (
     extensions: customExtensions,
     content: initialValue,
     injectCSS: false,
-    autofocus: autoFocus && "end",
+    autofocus: "end",
     editorProps: {
       attributes: {
         class: editorClasses,
@@ -113,6 +113,7 @@ const Editor = (
     parseOptions: {
       preserveWhitespace: true,
     },
+    onCreate: ({ editor }) => !autoFocus && editor.commands.blur(),
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
     onFocus,
     onBlur,

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -16,6 +16,7 @@ import {
   getEditorStyles,
   getIsPlaceholderActive,
   clipboardTextParser,
+  setInitialPosition,
 } from "./helpers";
 
 const Editor = (
@@ -102,7 +103,7 @@ const Editor = (
     extensions: customExtensions,
     content: initialValue,
     injectCSS: false,
-    autofocus: "end",
+    autofocus: autoFocus && "end",
     editorProps: {
       attributes: {
         class: editorClasses,
@@ -113,7 +114,7 @@ const Editor = (
     parseOptions: {
       preserveWhitespace: true,
     },
-    onCreate: ({ editor }) => !autoFocus && editor.commands.blur(),
+    onCreate: ({ editor }) => !autoFocus && setInitialPosition(editor),
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
     onFocus,
     onBlur,


### PR DESCRIPTION
Fixes #310 

**Description**

- Fixed issue where variables added get appended to starting of the existing content rather than at the end.

**Checklist**

- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

@AbhayVAshokan _a Please verify and merge if looks good.

