### PR TITLE
Added type support to exported components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,17 @@
   "name": "@bigbinary/neeto-editor",
   "version": "0.7.1",
   "main": "./build/index.js",
+  "types": "./types.d.ts",
   "description": "neetoEditor is the library that drives the rich text experience in all neeto products built at BigBinary",
   "keywords": [
     "ui",
     "rich-text-editor",
     "editor",
     "react"
+  ],
+  "files": [
+    "dist",
+    "types.d.ts"
   ],
   "author": "BigBinary",
   "license": "MIT",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,78 @@
+import { UppyOptions } from "@uppy/core/types";
+import {
+  Editor as TiptapEditor,
+  Extension,
+  Node,
+} from "@tiptap/core/dist/packages/core/src";
+import { Range } from "@tiptap/core/dist/packages/core/src/types";
+import { Transaction } from "prosemirror-state";
+
+interface Command {
+  title: string;
+  Icon: Function;
+  description?: string;
+  optionName: string;
+  command?: (props: { editor: TiptapEditor; range: Range }) => void;
+  items?: Command[];
+}
+
+interface Variable {
+  category_key: string;
+  category_label: string;
+  variables?: Array<{ key: string; label: string }>;
+}
+
+interface Mention {
+  key?: string;
+  name: string;
+  imageUrl?: string;
+}
+
+type KeyboardShortcuts = {
+  [shortcut: string]: (props: { editor: TiptapEditor }) => boolean | void;
+};
+
+type EditorFocus = (props: {
+  editor: TiptapEditor;
+  event: FocusEvent;
+  transaction: Transaction;
+}) => void;
+
+export function Editor(props: {
+  forceTitle?: boolean;
+  titleError?: boolean;
+  hideSlashCommands?: boolean;
+  defaults?: string[];
+  addons?: string[];
+  addonCommands?: Command[];
+  className?: string;
+  uploadEndpoint?: string;
+  uploadConfig?: UppyOptions<Record<string, unknown>>;
+  initialValue?: string;
+  onChange?: (htmlContent: string) => void;
+  onFocus?: EditorFocus;
+  onBlur?: EditorFocus;
+  menuType?: string;
+  variables?: Variable[];
+  mentions?: Mention[];
+  showImageInMention?: boolean;
+  placeholder?: { title: string } | string | null;
+  extensions?: Array<Node | Extension>;
+  contentClassName?: string[];
+  characterLimit?: number;
+  editorSecrets?: Array<{ unsplash?: string }>;
+  rows?: number;
+  autoFocus?: boolean;
+  onSubmit?: (htmlContent: string) => void;
+  heightStrategy?: string;
+  characterCountStrategy?: string;
+  keyboardShortcuts?: KeyboardShortcuts;
+  error?: string;
+  [otherProps: string]: any;
+}): JSX.Element;
+
+export function EditorContent(props: {
+  content?: string;
+  className?: string;
+  [otherProps: string]: any;
+}): JSX.Element;


### PR DESCRIPTION
Fixes #326

**Description**
- Added: type support to all the exported components.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
