### PR TITLE
Fixed the broken styles in mentions

### DIFF
--- a/lib/styles/editor/_editor-content.scss
+++ b/lib/styles/editor/_editor-content.scss
@@ -122,8 +122,8 @@
     padding: 4px 6px;
   }
 
-  [data-mention] {
-    opacity: 0.6;
+  [data-type="mention"] {
+    color: $neeto-ui-info;
   }
 }
 

--- a/lib/styles/editor/_editor.scss
+++ b/lib/styles/editor/_editor.scss
@@ -42,10 +42,6 @@
     padding: 4px 6px;
   }
 
-  [data-mention] {
-    opacity: 0.6;
-  }
-
   .ProseMirror-separator {
     display: none;
   }


### PR DESCRIPTION
Fixes #349 

**Description**
- Fixed: the broken styles in mentions.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] ~~have made corresponding changes to the documentation.~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

- The mentions styles were broken when `@tiptap/extension-mentions` was updated.
@karthiknmenon _a WDYT about this change?

<img width="437" alt="image" src="https://user-images.githubusercontent.com/35297280/190463754-b22a6a0d-0778-42df-acd3-a717c25d62e8.png">


<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
