### PR TITLE
Added type='submit' to BubbleMenu buttons

### DIFF
--- a/lib/components/Editor/CustomExtensions/BubbleMenu/TextOptions.jsx
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/TextOptions.jsx
@@ -55,6 +55,7 @@ const TextOptions = ({
         onClickOutside={handleClose}
         content={dropdownOptions.map(({ optionName, command }) => (
           <button
+            type="button"
             key={optionName}
             onClick={() => {
               command();
@@ -67,6 +68,7 @@ const TextOptions = ({
         ))}
       >
         <button
+          type="button"
           onClick={() => setIsDropdownOpen(open => !open)}
           className="neeto-editor-bubble-menu__item neeto-editor-bubble-menu__dropdown-target"
         >


### PR DESCRIPTION
Fixes #367

**Description**

- Fixed: prevent clicking of _BubbleMenu_ buttons from submitting the form.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] ~~I have made corresponding changes to the documentation.~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
