### PR TITLE
Removed the involvement of `@rails/activestorage` in image upload logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ The **neetoEditor** library drives the rich text experience in the
 yarn add @bigbinary/neeto-editor
 ```
 
-Install all the peer dependencies.
-
-```
-yarn add @rails/activestorage
-```
-
 For setting up image upload refer
 https://neeto-editor.onrender.com/?path=/docs/examples-customize-options-addons--addons.
 

--- a/lib/apis/directUploads.js
+++ b/lib/apis/directUploads.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+const generate = (url, payload, config) => axios.post(url, payload, config);
+
+const create = (url, file, config) =>
+  axios.put(url, file, {
+    ...config,
+    transformResponseCase: false,
+    transformRequestCase: false,
+    includeMetadataInResponse: true,
+  });
+
+const directUploadsApi = { generate, create };
+
+export default directUploadsApi;

--- a/lib/apis/directUploads.js
+++ b/lib/apis/directUploads.js
@@ -2,13 +2,7 @@ import axios from "axios";
 
 const generate = (url, payload, config) => axios.post(url, payload, config);
 
-const create = (url, file, config) =>
-  axios.put(url, file, {
-    ...config,
-    transformResponseCase: false,
-    transformRequestCase: false,
-    includeMetadataInResponse: true,
-  });
+const create = (url, file, config) => axios.put(url, file, { ...config });
 
 const directUploadsApi = { generate, create };
 

--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -1,7 +1,7 @@
-import { DirectUpload } from "@rails/activestorage";
 import Image from "@tiptap/extension-image";
 import { mergeAttributes, ReactNodeViewRenderer } from "@tiptap/react";
 import { Plugin } from "prosemirror-state";
+import DirectUpload from "utils/DirectUpload";
 
 import ImageComponent from "./ImageComponent";
 
@@ -99,16 +99,15 @@ const ImageExtension = Image.extend({
   },
 });
 
-const upload = (file, url) =>
-  new Promise((resolve, reject) => {
-    const uploader = new DirectUpload(file, url);
-
-    uploader.create((error, { blob_url: imageUrl }) => {
-      if (error) return reject(error);
-
-      return resolve(imageUrl);
-    });
-  });
+const upload = async (file, url) => {
+  const uploader = new DirectUpload({ file, url });
+  try {
+    const { blob_url: imageUrl } = await uploader.create();
+    return Promise.resolve(imageUrl);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
 
 export default {
   configure: ({ uploadEndpoint }) =>

--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -101,12 +101,8 @@ const ImageExtension = Image.extend({
 
 const upload = async (file, url) => {
   const uploader = new DirectUpload({ file, url });
-  try {
-    const { blob_url: imageUrl } = await uploader.create();
-    return Promise.resolve(imageUrl);
-  } catch (error) {
-    return Promise.reject(error);
-  }
+  const { blob_url: imageUrl } = await uploader.create();
+  return imageUrl;
 };
 
 export default {

--- a/lib/constants/common.js
+++ b/lib/constants/common.js
@@ -40,6 +40,6 @@ export const FONT_SIZE_OPTIONS = [
   { label: "H3", value: 3 },
 ];
 
-export const DIRECT_UPLOAD_ENDPOINT = "/api/v1/direct_uploads";
+export const DIRECT_UPLOAD_ENDPOINT = "/api/direct_uploads";
 
 export const CODE_BLOCK_REGEX = /<pre><code>([\S\s]*?)<\/code><\/pre>/gim;

--- a/lib/utils/ActiveStorageUpload.js
+++ b/lib/utils/ActiveStorageUpload.js
@@ -61,11 +61,11 @@ class ActiveStorageUpload extends BasePlugin {
       const blob = await upload.create();
       this.uppy.setFileState(file.id, { response: { status: "success" } });
       this.uppy.emit("upload-success", file, blob);
-      return Promise.resolve(file);
+      return file;
     } catch (error) {
       this.uppy.setFileState(file.id, { response: { status: "error" } });
       this.uppy.emit("upload-error", file, error);
-      return Promise.reject(error);
+      return error;
     }
   };
 }

--- a/lib/utils/ActiveStorageUpload.js
+++ b/lib/utils/ActiveStorageUpload.js
@@ -1,6 +1,5 @@
-import { DirectUpload } from "@rails/activestorage";
 import { BasePlugin } from "@uppy/core";
-import { mergeRight } from "ramda";
+import DirectUpload from "utils/DirectUpload";
 
 class ActiveStorageUpload extends BasePlugin {
   constructor(uppy, opts) {
@@ -9,16 +8,6 @@ class ActiveStorageUpload extends BasePlugin {
     this.type = "uploader";
     this.id = opts.id || "ActiveStorageUpload";
     this.title = opts.title || "Active Storage Upload";
-    this.token = opts.token || "";
-    this.attachmentName = opts.attachmentName || "";
-
-    const defaultOptions = {
-      timeout: 30 * 1000,
-      limit: 0,
-      directUploadUrl: this.opts.directUploadUrl,
-    };
-
-    this.opts = mergeRight(defaultOptions, opts);
   }
 
   install() {
@@ -37,110 +26,48 @@ class ActiveStorageUpload extends BasePlugin {
     return Promise.all(promises);
   };
 
-  uploadFile = file =>
-    new Promise((resolve, reject) => {
-      const timer = this.createProgressTimeout(this.opts.timeout, error => {
-        this.uppy.emit("upload-error", file, error);
-        reject(error);
-      });
-
-      const directHandlers = {
-        directUploadWillStoreFileWithXHR: null,
-        directUploadDidProgress: null,
-      };
-
-      directHandlers.directUploadDidProgress = xhr => {
-        timer.progress();
-
-        if (xhr.lengthComputable) {
-          this.uppy.emit("upload-progress", file, {
-            uploader: this,
-            bytesUploaded: xhr.loaded,
-            bytesTotal: xhr.total,
-          });
-        }
-      };
-
-      directHandlers.directUploadWillStoreFileWithXHR = request => {
-        request.upload.addEventListener("progress", event =>
-          directHandlers.directUploadDidProgress(event)
-        );
-      };
-
-      const { data, meta } = file;
-
-      if (!data.name && meta.name) {
-        data.name = meta.name;
+  uploadFile = async file => {
+    const handleProgress = xhr => {
+      if (xhr.lengthComputable) {
+        this.uppy.emit("upload-progress", file, {
+          uploader: this,
+          bytesUploaded: xhr.loaded,
+          bytesTotal: xhr.total,
+        });
       }
+    };
 
-      const upload = new DirectUpload(
-        data,
-        this.opts.directUploadUrl,
-        this.opts.token,
-        this.opts.attachmentName,
-        directHandlers
-      );
-
-      upload.create((error, blob) => {
-        timer.done();
-
-        if (error) {
-          const response = { status: "error" };
-          this.uppy.setFileState(file.id, { response });
-          this.uppy.emit("upload-error", file, error);
-          return reject(error);
-        }
-        const response = {
-          status: "success",
-          directUploadSignedId: blob.signed_id,
-        };
-        this.uppy.setFileState(file.id, { response });
-        this.uppy.emit("upload-success", file, blob);
-        return resolve(file);
-      });
-
-      this.uppy.on("file-removed", removedFile => {
-        if (removedFile.id === file.id) {
-          timer.done();
-          upload.abort?.();
-        }
-      });
-
-      this.uppy.on("upload-cancel", fileID => {
-        if (fileID === file.id) {
-          timer.done();
-          upload.abort?.();
-        }
-      });
-
-      this.uppy.on("cancel-all", () => {
-        timer.done();
-        upload.abort?.();
-      });
+    this.uppy.on("file-removed", removedFile => {
+      if (removedFile.id === file.id) {
+        upload.abort();
+      }
     });
 
-  // Helper to abort the request if it exceeds `duration` milli seconds.
-  createProgressTimeout(duration, errorCallback) {
-    let timer = null;
-    let isDone = false;
-
-    const progress = () => {
-      if (isDone) return;
-
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => errorCallback("Request timed out."), duration);
-    };
-
-    const done = () => {
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
+    this.uppy.on("upload-cancel", fileID => {
+      if (fileID === file.id) {
+        upload.abort();
       }
-      isDone = true;
-    };
+    });
 
-    return { progress, done };
-  }
+    this.uppy.on("cancel-all", () => upload.abort());
+
+    const upload = new DirectUpload({
+      file: file.data,
+      url: this.opts.directUploadUrl,
+      progress: handleProgress,
+    });
+
+    try {
+      const blob = await upload.create();
+      this.uppy.setFileState(file.id, { response: { status: "success" } });
+      this.uppy.emit("upload-success", file, blob);
+      return Promise.resolve(file);
+    } catch (error) {
+      this.uppy.setFileState(file.id, { response: { status: "error" } });
+      this.uppy.emit("upload-error", file, error);
+      return Promise.reject(error);
+    }
+  };
 }
 
 export default ActiveStorageUpload;

--- a/lib/utils/ActiveStorageUpload.js
+++ b/lib/utils/ActiveStorageUpload.js
@@ -65,7 +65,7 @@ class ActiveStorageUpload extends BasePlugin {
     } catch (error) {
       this.uppy.setFileState(file.id, { response: { status: "error" } });
       this.uppy.emit("upload-error", file, error);
-      return error;
+      throw error;
     }
   };
 }

--- a/lib/utils/DirectUpload/index.js
+++ b/lib/utils/DirectUpload/index.js
@@ -1,0 +1,46 @@
+import directUploadsApi from "apis/directUploads";
+import { noop } from "utils/common";
+
+import { generateChecksum } from "./utils";
+
+class DirectUpload {
+  constructor({ url, file, progress = noop }) {
+    this.url = url;
+    this.file = file;
+    this.progress = progress;
+  }
+
+  create = async () => {
+    try {
+      const { data } = await this.generateUrl();
+      const {
+        direct_upload: { url, headers },
+      } = data;
+      await this.uploadToCloud(url, headers);
+      return Promise.resolve(data);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
+
+  generateUrl = async () => {
+    const payload = {
+      blob: {
+        filename: this.file.name,
+        byte_size: this.file.size,
+        content_type: this.file.type,
+        checksum: await generateChecksum(this.file),
+      },
+    };
+    return directUploadsApi.generate(this.url, payload);
+  };
+
+  abort = () => {};
+
+  uploadToCloud = (url, headers) => {
+    const config = { headers, onUploadProgress: this.progress };
+    return directUploadsApi.create(url, this.file, config);
+  };
+}
+
+export default DirectUpload;

--- a/lib/utils/DirectUpload/index.js
+++ b/lib/utils/DirectUpload/index.js
@@ -12,16 +12,12 @@ class DirectUpload {
   }
 
   create = async () => {
-    try {
-      const { data } = await this.generateUrl();
-      const {
-        direct_upload: { url, headers },
-      } = data;
-      await this.uploadToCloud(url, headers);
-      return Promise.resolve(data);
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    const { data } = await this.generateUrl();
+    const {
+      direct_upload: { url, headers },
+    } = data;
+    await this.uploadToCloud(url, headers);
+    return data;
   };
 
   generateUrl = async () => {

--- a/lib/utils/DirectUpload/index.js
+++ b/lib/utils/DirectUpload/index.js
@@ -8,6 +8,7 @@ class DirectUpload {
     this.url = url;
     this.file = file;
     this.progress = progress;
+    this.abortController = new AbortController();
   }
 
   create = async () => {
@@ -35,10 +36,14 @@ class DirectUpload {
     return directUploadsApi.generate(this.url, payload);
   };
 
-  abort = () => {};
+  abort = () => this.abortController.abort();
 
   uploadToCloud = (url, headers) => {
-    const config = { headers, onUploadProgress: this.progress };
+    const config = {
+      headers,
+      onUploadProgress: this.progress,
+      signal: this.abortController.signal,
+    };
     return directUploadsApi.create(url, this.file, config);
   };
 }

--- a/lib/utils/DirectUpload/utils.js
+++ b/lib/utils/DirectUpload/utils.js
@@ -1,0 +1,20 @@
+import CryptoJS from "crypto-js";
+
+const md5FromFile = file =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = event => {
+      const binary = CryptoJS.lib.WordArray.create(event.target.result);
+      resolve(CryptoJS.MD5(binary));
+    };
+
+    reader.onerror = () => reject(new Error("Corrupted file"));
+    reader.readAsArrayBuffer(file);
+  });
+
+export const generateChecksum = async file => {
+  const md5 = await md5FromFile(file);
+  const checksum = md5.toString(CryptoJS.enc.Base64);
+  return checksum;
+};

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babel-loader": "8.2.5",
     "babel-plugin-ramda": "2.1.1",
     "classnames": "2.3.1",
+    "crypto-js": "^4.1.1",
     "css-loader": "6.7.1",
     "dompurify": "2.3.10",
     "emoji-mart": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@babel/preset-env": "7.18.9",
     "@babel/preset-react": "7.18.6",
     "@bigbinary/neeto-icons": "1.8.37",
-    "@rails/activestorage": "7.0.3-1",
     "@rollup/plugin-alias": "3.1.9",
     "@rollup/plugin-babel": "5.3.1",
     "@rollup/plugin-commonjs": "22.0.1",
@@ -115,7 +114,6 @@
     "webpack-dev-server": "4.9.3"
   },
   "peerDependencies": {
-    "@rails/activestorage": "7.0.3-1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-transition-group": "^4.4.5"

--- a/package.json
+++ b/package.json
@@ -115,8 +115,7 @@
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-transition-group": "^4.4.5"
+    "react-dom": "17.0.2"
   },
   "scripts": {
     "start": "yarn storybook",

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -88,7 +88,7 @@ export const EDITOR_PROP_TABLE_ROWS = [
   [
     "uploadEndpoint",
     "Accepts an URL endpoint string. This URL will be used for XHR image uploads.",
-    `"/api/v1/direct_uploads"`,
+    `"/api/direct_uploads"`,
   ],
   [
     "variables",

--- a/stories/Examples/Customize-options/Addons.stories.mdx
+++ b/stories/Examples/Customize-options/Addons.stories.mdx
@@ -54,15 +54,6 @@ Image upload feature can be enabled in neetoEditor by adding the `image-upload`
 addon to the list of addons. All the images are uploaded using a pre-signed URL
 from the backend.
 
-For handling these requests, neetoEditor uses the `@rails/activestorage`
-package. It needs to be initialized in the host project by adding the following
-lines before the editor is mounted:
-
-```js
-import * as activestorage from "@rails/activestorage";
-activestorage.start();
-```
-
 #### **Integration with Rails**
 
 Rails provides a `DirectUploadsController` to handle direct upload to the

--- a/stories/Getting-started.stories.mdx
+++ b/stories/Getting-started.stories.mdx
@@ -23,12 +23,6 @@ import { Meta } from "@storybook/addon-docs";
 yarn add @bigbinary/neeto-editor
 ```
 
-Add the **@rails/activestorage** package as a peer dependencies.
-
-```
-yarn add @rails/activestorage
-```
-
 </div>
 
 ### **Usage**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,6 +5301,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,13 +1479,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
-"@rails/activestorage@7.0.3-1":
-  version "7.0.3-1"
-  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-7.0.3-1.tgz#1b17d830fe065b2f73cc7aaea4dd1a4177bee6cf"
-  integrity sha512-8tDzsfVyJtkq/nxRT8dHuyYaZMfWQy8Qkm/InIBmf/e3vZ3kyLMF7yJ88qZf6ghbNgjHbjrJdh6wNoXnJjvKjw==
-  dependencies:
-    spark-md5 "^3.0.1"
-
 "@rollup/plugin-alias@3.1.9":
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
@@ -11772,11 +11765,6 @@ space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
-
-spark-md5@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
-  integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
Fixes #374 

**Description**
- Changed: image upload no longer depends on the `@rails/activestorage` package.
- Removed: `@rails/activestorage` package from peer dependencies.
- Removed: `react-group-transition` package from peer dependencies.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

- Removed `@rails/activestorage` package and used a class-based approach using Promises to upload images.
- The `ActiveStorageUpload` class now contains minimal logic related to image upload. Ideally all the uploading config must be passed down via uppyProps from editor.

I am planning to add neetoEditor as part of `package-common.json` of `neeto_commons` so that all the projects will stay in sync with all the versions. As part of that:
1. 2d79e0f50c0c770b9bd4b708ff9d799d3c5f25af: `react-transition-group` is removed from peer dependencies. It is lightweight, and will not be useful in parent project.
2. 41db037e9729c2a0d4953db4638cae0e60ddff43: Updated default URL endpoint.
3. https://github.com/bigbinary/neeto_commons/issues/504: Will extract `Api::V1::DirectUploadsController` to `Api::DirectUploadsController` of `neeto_commons` (hence the URL change above).

@labeebklatif _a please review.
Demo: https://vimeo.com/754358008/95abbef2d3

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
