### PR TITLE
Fixed issue where mentions and variables menu item is always active

### DIFF
--- a/lib/components/Editor/CustomExtensions/Mention/index.jsx
+++ b/lib/components/Editor/CustomExtensions/Mention/index.jsx
@@ -1,10 +1,11 @@
 import React, { useRef } from "react";
 
+import { Email } from "neetoicons";
+import { isEmpty } from "ramda";
+
 import Avatar from "components/Common/Avatar";
 import Dropdown from "components/Common/Dropdown";
 import MenuButton from "components/Common/MenuButton";
-import { Email } from "neetoicons";
-import { isEmpty } from "ramda";
 
 import { formatMentions } from "./helpers";
 
@@ -21,7 +22,7 @@ const Mentions = ({ editor, mentions, showImageInMention }) => {
       customTarget={() => (
         <MenuButton
           icon={Email}
-          iconActive={dropdownRef.current?.visible}
+          iconActive={dropdownRef?.current?._tippy?.state?.isVisible}
           tooltipProps={{
             content: "Mention",
             position: "bottom",

--- a/lib/components/Editor/CustomExtensions/Variable/index.jsx
+++ b/lib/components/Editor/CustomExtensions/Variable/index.jsx
@@ -1,8 +1,9 @@
 import React, { useRef } from "react";
 
+import { Braces } from "neetoicons";
+
 import Dropdown from "components/Common/Dropdown";
 import MenuButton from "components/Common/MenuButton";
-import { Braces } from "neetoicons";
 
 import VariableList from "./VariableList";
 
@@ -26,7 +27,7 @@ const Variables = ({ editor, variables }) => {
       customTarget={() => (
         <MenuButton
           icon={Braces}
-          iconActive={dropdownRef.current?.visible}
+          iconActive={dropdownRef?.current?._tippy?.state?.isVisible}
           tooltipProps={{
             content: "Variables",
             position: "bottom",


### PR DESCRIPTION
Fixes #384

**Description**

- Fixed: issue where the mentions menu item in fixed menu was always active.
- Fixed: issue where the variables menu item in fixed menu was always active.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
