### PR TITLE
Prevented strings with HTML tag structure from getting converted to actual tags

### DIFF
--- a/lib/utils/highlightCode.js
+++ b/lib/utils/highlightCode.js
@@ -17,16 +17,17 @@ const buildReactElementFromAST = element => {
 };
 
 const highlightCode = content =>
-  content
-    .replaceAll("&gt;", ">")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&amp;", "&")
-    .replaceAll(CODE_BLOCK_REGEX, (_, code) => {
-      const highlightedAST = lowlight.highlightAuto(code);
-      const highlightedNode = highlightedAST.children.map(
-        buildReactElementFromAST
-      );
-      return `<pre><code>${renderToString(highlightedNode)}</code></pre>`;
-    });
+  content.replaceAll(CODE_BLOCK_REGEX, (_, code) => {
+    const highlightedAST = lowlight.highlightAuto(
+      code
+        .replaceAll("&gt;", ">")
+        .replaceAll("&lt;", "<")
+        .replaceAll("&amp;", "&")
+    );
+    const highlightedNode = highlightedAST.children.map(
+      buildReactElementFromAST
+    );
+    return `<pre><code>${renderToString(highlightedNode)}</code></pre>`;
+  });
 
 export default highlightCode;


### PR DESCRIPTION
Fixes #392 

**Description**

- Fixed: Prevented strings with HTML tag structure from getting converted to actual tags.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**


@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
