### PR TITLE
Removed second scrollbar from emoji picker

### DIFF
--- a/lib/components/Editor/CustomExtensions/FixedMenu/EmojiOption.jsx
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/EmojiOption.jsx
@@ -1,8 +1,9 @@
 import React, { useRef } from "react";
 
+import { Smiley } from "neetoicons";
+
 import Dropdown from "components/Common/Dropdown";
 import MenuButton from "components/Common/MenuButton";
-import { Smiley } from "neetoicons";
 
 import EmojiPickerMenu from "../Emoji/EmojiPicker/EmojiPickerMenu";
 
@@ -23,6 +24,7 @@ const EmojiOption = ({ editor }) => {
         />
       )}
       position="bottom-start"
+      dropdownProps={{ classNames: "neeto-editor-fixed-menu__emoji-dropdown" }}
     >
       <Menu>
         <EmojiPickerMenu editor={editor} />

--- a/lib/styles/editor/_menu.scss
+++ b/lib/styles/editor/_menu.scss
@@ -37,6 +37,10 @@
     align-items: center;
     margin-left: auto;
   }
+
+  .neeto-editor-fixed-menu__emoji-dropdown {
+    max-height: unset;
+  }
 }
 
 .neeto-editor-variables-suggestion {


### PR DESCRIPTION
Fixes #398 

**Description**

- Fixed: Removed second scrollbar from emoji picker.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
