### PR TITLE
Extracted menu as an independant component

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "moduleResolution": "NodeNext",
-    "baseUrl": ".",
+    "baseUrl": "./lib",
     "paths": {
       "apis/*": ["apis/*"],
       "apis": ["apis"],
@@ -27,8 +27,8 @@
       "translations": ["translations"],
       "utils/*": ["utils/*"],
       "utils": ["utils"],
-      "neetoicons/*": ["node_modules/@bigbinary/neeto-icons/*"],
-      "neetoicons": ["node_modules/@bigbinary/neeto-icons"]
+      "neetoicons/*": ["../node_modules/@bigbinary/neeto-icons/*"],
+      "neetoicons": ["../node_modules/@bigbinary/neeto-icons"]
     },
     "pretty": true,
     "experimentalDecorators": true,

--- a/lib/components/Editor/CustomExtensions/BubbleMenu/utils.jsx
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/utils.jsx
@@ -105,8 +105,8 @@ export const getTextMenuDropdownOptions = ({ editor }) => [
 
 export const getImageMenuOptions = ({
   editor,
-  isImageEditorModalOpen,
-  setIsImageEditorModalOpen,
+  isImageUploadOpen,
+  setIsImageUploadOpen,
 }) => [
   {
     Icon: LeftAlign,
@@ -161,8 +161,8 @@ export const getImageMenuOptions = ({
   },
   {
     Icon: Edit,
-    command: () => setIsImageEditorModalOpen(true),
-    active: isImageEditorModalOpen,
+    command: () => setIsImageUploadOpen(true),
+    active: isImageUploadOpen,
     optionName: "Caption",
   },
   {

--- a/lib/components/Editor/CustomExtensions/CharacterCount/index.jsx
+++ b/lib/components/Editor/CustomExtensions/CharacterCount/index.jsx
@@ -1,11 +1,7 @@
 import React from "react";
 
-const CharacterCountWrapper = ({
-  editor,
-  isCharacterCountActive,
-  children,
-}) => {
-  if (!isCharacterCountActive || !editor) return children;
+const CharacterCountWrapper = ({ editor, isActive, children }) => {
+  if (!isActive || !editor) return children;
 
   return (
     <>

--- a/lib/components/Editor/CustomExtensions/FixedMenu/index.jsx
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { EDITOR_OPTIONS } from "common/constants";
 import Modal from "components/Common/Modal";
@@ -16,12 +16,12 @@ import Variables from "../Variable";
 
 const FixedMenu = ({
   editor,
-  variables,
-  setIsImageUploadVisible,
   options,
   mentions,
+  variables,
+  isImageUploadOpen,
+  setIsImageUploadOpen,
 }) => {
-  const [isImageEditorModalOpen, setIsImageEditorModalOpen] = useState(false);
   const selectedNode = editor && editor.view.state.selection.node;
   const isImageNodeSelected =
     selectedNode && selectedNode.type.name === "image";
@@ -35,7 +35,7 @@ const FixedMenu = ({
     block: blockStyleOptions,
     list: listStyleOptions,
     misc: miscOptions,
-  } = buildMenuOptions({ editor, options, setIsImageUploadVisible });
+  } = buildMenuOptions({ editor, options, setIsImageUploadOpen });
   const fontSizeOptions = options.filter(option => option.match(/^h[1-6]$/));
   const isFontSizeActive = fontSizeOptions.length > 0;
   const isEmojiActive = options.includes(EDITOR_OPTIONS.EMOJI);
@@ -53,8 +53,8 @@ const FixedMenu = ({
       {isImageNodeSelected &&
         getImageMenuOptions({
           editor,
-          isImageEditorModalOpen,
-          setIsImageEditorModalOpen,
+          isImageUploadOpen,
+          setIsImageUploadOpen,
         }).map(renderOptionButton)}
       <Separator />
       {isLinkActive && <LinkOption editor={editor} />}
@@ -64,8 +64,8 @@ const FixedMenu = ({
         <Variables editor={editor} variables={variables} />
       </div>
       <Modal
-        isOpen={isImageEditorModalOpen}
-        onClose={() => setIsImageEditorModalOpen(false)}
+        isOpen={isImageUploadOpen}
+        onClose={() => setIsImageUploadOpen(false)}
       >
         <div className="neeto-editor-image-uploader">
           <div className="neeto-editor-image-uploader__content">
@@ -73,7 +73,7 @@ const FixedMenu = ({
               alt={selectedNode?.attrs.alt}
               editor={editor}
               url={selectedNode?.attrs.src}
-              onClose={() => setIsImageEditorModalOpen(false)}
+              onClose={() => setIsImageUploadOpen(false)}
             />
           </div>
         </div>

--- a/lib/components/Editor/CustomExtensions/FixedMenu/utils.jsx
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/utils.jsx
@@ -7,12 +7,8 @@ import { humanize } from "utils/common";
 
 import { MENU_OPTIONS } from "./constants";
 
-export const buildMenuOptions = ({
-  editor,
-  options,
-  setIsImageUploadVisible,
-}) => {
-  const menuOptions = MENU_OPTIONS(editor, setIsImageUploadVisible);
+export const buildMenuOptions = ({ editor, options, setIsImageUploadOpen }) => {
+  const menuOptions = MENU_OPTIONS(editor, setIsImageUploadOpen);
 
   return fromPairs(
     ["font", "block", "list", "misc"].map(option => [
@@ -30,16 +26,16 @@ export const renderOptionButton = ({
   highlight,
 }) => (
   <MenuButton
-    key={optionName}
+    data-cy={`neeto-editor-fixed-menu-${optionName}-option`}
+    highlight={highlight}
     icon={Icon}
     iconActive={active}
-    highlight={highlight}
-    onClick={command}
+    key={optionName}
     tooltipProps={{
       content: humanize(optionName),
       position: "bottom",
       delay: [500],
     }}
-    data-cy={`neeto-editor-fixed-menu-${optionName}-option`}
+    onClick={command}
   />
 );

--- a/lib/components/Editor/CustomExtensions/Image/ImageEditor.jsx
+++ b/lib/components/Editor/CustomExtensions/Image/ImageEditor.jsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import Button from "components/Common/Button";
 import Input from "components/Common/Input";
 
-const ImageEditor = ({ url, editor, onClose, alt }) => {
+const ImageEditor = ({ url, editor, onClose, alt = "" }) => {
   const [altText, setAltText] = useState(alt || "");
   const [isError, setIsError] = useState(false);
 

--- a/lib/components/Editor/CustomExtensions/Image/Uploader.jsx
+++ b/lib/components/Editor/CustomExtensions/Image/Uploader.jsx
@@ -11,11 +11,11 @@ import UnsplashImagePicker from "./UnsplashImagePicker";
 import URLForm from "./URLForm";
 
 const ImageUpload = ({
+  isOpen,
+  onClose,
   editor,
   imageUploadUrl,
   uploadConfig,
-  isVisible,
-  setIsVisible,
   unsplashApiKey,
 }) => {
   const [activeTab, setActiveTab] = useTabBar(IMAGE_UPLOAD_OPTIONS);
@@ -54,9 +54,9 @@ const ImageUpload = ({
   return (
     <Modal
       closeButton={false}
-      isOpen={isVisible}
+      isOpen={isOpen}
       onClose={() => {
-        setIsVisible(false);
+        onClose();
         setActiveTab(IMAGE_UPLOAD_OPTIONS[0]);
       }}
     >
@@ -80,8 +80,8 @@ const ImageUpload = ({
               editor={editor}
               url={imageUrl}
               onClose={() => {
-                setImageUrl(null);
-                setIsVisible(false);
+                setImageUrl("");
+                onClose();
               }}
             />
           ) : (

--- a/lib/components/Editor/CustomExtensions/SlashCommands/CommandsList.jsx
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/CommandsList.jsx
@@ -1,9 +1,12 @@
 import React from "react";
 
 import Menu from "./Menu";
+import { addImageUpdateLogicToCommandItems } from "./utils";
+
+import ImageUploader from "../Image/Uploader";
 
 class CommandsList extends React.Component {
-  state = { activeMenuIndex: 0 };
+  state = { activeMenuIndex: 0, isImageUploadOpen: false };
 
   onKeyDown = ({ event }) =>
     ["Enter", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(
@@ -13,13 +16,28 @@ class CommandsList extends React.Component {
   setActiveMenuIndex = index => this.setState({ activeMenuIndex: index });
 
   render() {
+    const items = addImageUpdateLogicToCommandItems(this.props.items, () =>
+      this.setState({ isImageUploadOpen: true })
+    );
+
     return (
-      <Menu
-        {...this.props}
-        activeMenuIndex={this.state.activeMenuIndex}
-        menuIndex={0}
-        setActiveMenuIndex={this.setActiveMenuIndex}
-      />
+      <>
+        <Menu
+          {...this.props}
+          activeMenuIndex={this.state.activeMenuIndex}
+          items={items}
+          menuIndex={0}
+          setActiveMenuIndex={this.setActiveMenuIndex}
+        />
+        <ImageUploader
+          editor={this.props.editor}
+          imageUploadUrl={this.props.uploadEndpoint}
+          isOpen={this.state.isImageUploadOpen}
+          unsplashApiKey={this.props.editorSecrets.unsplash}
+          uploadConfig={this.props.uploadConfig}
+          onClose={() => this.setState({ isImageUploadOpen: false })}
+        />
+      </>
     );
   }
 }

--- a/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -17,12 +17,14 @@ import { buildCommandItems } from "./utils";
 const CommandsPluginKey = new PluginKey("commands");
 
 export default {
-  configure: ({ setIsImageUploadVisible, addonCommands, options }) => {
-    const commandItems = buildCommandItems({
-      permittedOptions: options,
-      addonCommands,
-      setIsImageUploadVisible,
-    });
+  configure: ({
+    addonCommands,
+    options,
+    uploadEndpoint,
+    editorSecrets,
+    uploadConfig,
+  }) => {
+    const commandItems = buildCommandItems({ options, addonCommands });
 
     return Extension.create({
       name: "slash-commands",
@@ -57,7 +59,12 @@ export default {
               return {
                 onStart: props => {
                   reactRenderer = new ReactRenderer(CommandsList, {
-                    props,
+                    props: {
+                      ...props,
+                      uploadEndpoint,
+                      editorSecrets,
+                      uploadConfig,
+                    },
                     editor: props.editor,
                   });
 

--- a/lib/components/Editor/CustomExtensions/SlashCommands/utils.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/utils.js
@@ -1,4 +1,4 @@
-import { assoc } from "ramda";
+import { assoc, findIndex, modify, propEq } from "ramda";
 
 import {
   YOUTUBE_URL_REGEXP,
@@ -6,6 +6,7 @@ import {
   LOOM_URL_REGEXP,
   EDITOR_OPTIONS,
 } from "common/constants";
+import { noop } from "utils/common";
 
 import { MENU_ITEMS } from "./constants";
 
@@ -30,21 +31,10 @@ const embedCommand = ({ editor, range }) => {
   }
 };
 
-const imageCommand =
-  setIsImageUploadVisible =>
-  ({ editor, range }) => {
-    setIsImageUploadVisible(true);
-    editor.chain().focus().deleteRange(range).run();
-  };
-
-export const buildCommandItems = ({
-  permittedOptions,
-  setIsImageUploadVisible,
-  addonCommands,
-}) => {
+export const buildCommandItems = ({ options, addonCommands }) => {
   const commandItems = MENU_ITEMS.map(item => {
     if (item.optionName === EDITOR_OPTIONS.IMAGE_UPLOAD) {
-      return assoc("command", imageCommand(setIsImageUploadVisible), item);
+      return assoc("command", noop, item);
     } else if (item.optionName === EDITOR_OPTIONS.VIDEO_EMBED) {
       return assoc("command", embedCommand, item);
     }
@@ -53,11 +43,21 @@ export const buildCommandItems = ({
   });
 
   const permittedCommandItems = commandItems.filter(({ optionName }) =>
-    permittedOptions.includes(optionName)
+    options.includes(optionName)
   );
 
   return [...permittedCommandItems, ...addonCommands];
 };
+
+export const addImageUpdateLogicToCommandItems = (items, openImageUploader) =>
+  modify(
+    findIndex(propEq("optionName", EDITOR_OPTIONS.IMAGE_UPLOAD), items),
+    assoc("command", ({ editor, range }) => {
+      openImageUploader();
+      editor.chain().focus().deleteRange(range).run();
+    }),
+    items
+  );
 
 export const validateYouTubeUrl = url => {
   const match = url.match(YOUTUBE_URL_REGEXP);

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -34,6 +34,8 @@ const useCustomExtensions = ({
   keyboardShortcuts,
   uploadEndpoint,
   config,
+  editorSecrets,
+  uploadConfig,
 }) => {
   const customConfig = mergeLeft(config, DEFAULT_CONFIG);
   let customExtensions = [
@@ -59,9 +61,11 @@ const useCustomExtensions = ({
   if (isSlashCommandsActive) {
     customExtensions.push(
       SlashCommands.configure({
-        setIsImageUploadVisible: () => {},
         options,
         addonCommands,
+        uploadEndpoint,
+        editorSecrets,
+        uploadConfig,
       })
     );
   }

--- a/lib/components/Editor/CustomExtensions/useCustomExtensions.js
+++ b/lib/components/Editor/CustomExtensions/useCustomExtensions.js
@@ -28,7 +28,6 @@ const useCustomExtensions = ({
   mentions,
   variables,
   isSlashCommandsActive,
-  setIsImageUploadVisible,
   options,
   addonCommands,
   onSubmit,
@@ -60,7 +59,7 @@ const useCustomExtensions = ({
   if (isSlashCommandsActive) {
     customExtensions.push(
       SlashCommands.configure({
-        setIsImageUploadVisible,
+        setIsImageUploadVisible: () => {},
         options,
         addonCommands,
       })

--- a/lib/components/Editor/Menu/index.jsx
+++ b/lib/components/Editor/Menu/index.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+
+import { DIRECT_UPLOAD_ENDPOINT } from "common/constants";
+
+import { DEFAULT_EDITOR_OPTIONS } from "../constants";
+import BubbleMenu from "../CustomExtensions/BubbleMenu";
+import FixedMenu from "../CustomExtensions/FixedMenu";
+import ImageUploader from "../CustomExtensions/Image/Uploader";
+
+const Menu = ({
+  editor,
+  menuType = "fixed",
+  defaults = DEFAULT_EDITOR_OPTIONS,
+  addons = [],
+  editorSecrets = {},
+  uploadEndpoint = DIRECT_UPLOAD_ENDPOINT,
+  uploadConfig = {},
+  mentions = [],
+  variables = [],
+}) => {
+  const [isImageUploadOpen, setIsImageUploadOpen] = useState(false);
+  const options = [...defaults, ...addons];
+  const isFixedMenuActive = menuType === "fixed";
+  const isBubbleMenuActive = menuType === "bubble";
+
+  return (
+    <>
+      {isFixedMenuActive && (
+        <FixedMenu
+          editor={editor}
+          isImageUploadOpen={isImageUploadOpen}
+          mentions={mentions}
+          options={options}
+          setIsImageUploadOpen={setIsImageUploadOpen}
+          variables={variables}
+        />
+      )}
+      {isBubbleMenuActive && (
+        <BubbleMenu editor={editor} mentions={mentions} options={options} />
+      )}
+      <ImageUploader
+        editor={editor}
+        imageUploadUrl={uploadEndpoint}
+        isOpen={isImageUploadOpen}
+        unsplashApiKey={editorSecrets.unsplash}
+        uploadConfig={uploadConfig}
+        onClose={() => setIsImageUploadOpen(false)}
+      />
+    </>
+  );
+};
+
+export default Menu;

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useImperativeHandle } from "react";
+import React, { useImperativeHandle } from "react";
 
 import { useEditor, EditorContent } from "@tiptap/react";
 import classnames from "classnames";
@@ -10,11 +10,9 @@ import useEditorWarnings from "hooks/useEditorWarnings";
 import { noop } from "utils/common";
 
 import { DEFAULT_EDITOR_OPTIONS } from "./constants";
-import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import CharacterCountWrapper from "./CustomExtensions/CharacterCount";
-import FixedMenu from "./CustomExtensions/FixedMenu";
-import ImageUploader from "./CustomExtensions/Image/Uploader";
 import useCustomExtensions from "./CustomExtensions/useCustomExtensions";
+import Menu from "./Menu";
 import {
   getEditorStyles,
   clipboardTextParser,
@@ -55,20 +53,17 @@ const Editor = (
   const isBubbleMenuActive = menuType === "bubble";
   const isSlashCommandsActive = !hideSlashCommands;
   const isPlaceholderActive = !!placeholder;
-  const addonOptions = [...defaults, ...addons];
 
-  const [isImageUploadVisible, setIsImageUploadVisible] = useState(false);
   const customExtensions = useCustomExtensions({
     placeholder,
     extensions,
     mentions,
     variables,
     isSlashCommandsActive,
-    setIsImageUploadVisible,
-    options: addonOptions,
+    options: [...defaults, ...addons],
     addonCommands,
-    keyboardShortcuts,
     onSubmit,
+    keyboardShortcuts,
     uploadEndpoint,
     config,
   });
@@ -112,33 +107,17 @@ const Editor = (
 
   return (
     <ErrorWrapper error={error} isFixedMenuActive={isFixedMenuActive}>
-      <CharacterCountWrapper
-        editor={editor}
-        isCharacterCountActive={isCharacterCountActive}
-      >
-        {isFixedMenuActive && (
-          <FixedMenu
-            editor={editor}
-            mentions={mentions}
-            options={addonOptions}
-            setIsImageUploadVisible={setIsImageUploadVisible}
-            variables={variables}
-          />
-        )}
-        {isBubbleMenuActive && (
-          <BubbleMenu
-            editor={editor}
-            mentions={mentions}
-            options={addonOptions}
-          />
-        )}
-        <ImageUploader
+      <CharacterCountWrapper editor={editor} isActive={isCharacterCountActive}>
+        <Menu
+          addons={addons}
+          defaults={defaults}
           editor={editor}
-          imageUploadUrl={uploadEndpoint}
-          isVisible={isImageUploadVisible}
-          setIsVisible={setIsImageUploadVisible}
-          unsplashApiKey={editorSecrets.unsplash}
+          editorSecrets={editorSecrets}
+          mentions={mentions}
+          menuType={menuType}
           uploadConfig={uploadConfig}
+          uploadEndpoint={uploadEndpoint}
+          variables={variables}
         />
         <EditorContent editor={editor} {...otherProps} />
       </CharacterCountWrapper>

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -66,6 +66,8 @@ const Editor = (
     keyboardShortcuts,
     uploadEndpoint,
     config,
+    editorSecrets,
+    uploadConfig,
   });
   useEditorWarnings({ initialValue });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 import Editor from "./components/Editor";
+import Menu from "./components/Editor/Menu";
 import EditorContent from "./components/EditorContent";
 import "./index.scss";
 
-export { Editor, EditorContent };
+export { Editor, EditorContent, Menu };


### PR DESCRIPTION
Fixes #407 

**Description**

- Added: a _Menu_ component. This can be used to render the editor menu separate from the editor.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
