### PR TITLE
Fixed the issue where placeholder overlaps dropdown

### DIFF
--- a/lib/styles/editor/_commands.scss
+++ b/lib/styles/editor/_commands.scss
@@ -84,5 +84,6 @@
   position: absolute;
   top: -2px;
   height: 0;
+  z-index: -1;
   pointer-events: none;
 }

--- a/lib/styles/editor/_menu.scss
+++ b/lib/styles/editor/_menu.scss
@@ -16,7 +16,6 @@
     justify-content: flex-start;
     align-items: center;
     overflow: auto;
-    max-width: 1056px;
     width: 100%;
   }
 


### PR DESCRIPTION
Fixes #437 

**Description**

- Fixed: the inteference of placeholder with dropdowns.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
