### PR TITLE
Passed className prop to editor wrapper

### DIFF
--- a/lib/components/Common/ErrorWrapper.jsx
+++ b/lib/components/Common/ErrorWrapper.jsx
@@ -28,6 +28,8 @@ const ErrorWrapper = ({ error, isFixedMenuActive, children }) => {
     return message;
   };
 
+  if (!error) return children;
+
   return (
     <>
       <div className={wrapperClasses}>{children}</div>

--- a/lib/components/Editor/Menu/index.jsx
+++ b/lib/components/Editor/Menu/index.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import classnames from "classnames";
+
 import { DIRECT_UPLOAD_ENDPOINT } from "common/constants";
 
 import { DEFAULT_EDITOR_OPTIONS } from "../constants";
@@ -29,7 +31,7 @@ const Menu = ({
     <>
       {isFixedMenuActive && (
         <FixedMenu
-          className={className}
+          className={classnames({ [className]: className })}
           editor={editor}
           isImageUploadOpen={isImageUploadOpen}
           isIndependant={isIndependant}

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -109,32 +109,36 @@ const Editor = (
   };
 
   return (
-    <ErrorWrapper error={error} isFixedMenuActive={isFixedMenuActive}>
-      <CharacterCountWrapper editor={editor} isActive={isCharacterCountActive}>
-        <Menu
-          addons={addons}
-          className={className}
-          defaults={defaults}
+    <div className={classnames({ [className]: className })}>
+      <ErrorWrapper error={error} isFixedMenuActive={isFixedMenuActive}>
+        <CharacterCountWrapper
           editor={editor}
-          editorSecrets={editorSecrets}
-          isIndependant={false}
-          mentions={mentions}
-          menuType={menuType}
-          uploadConfig={uploadConfig}
-          uploadEndpoint={uploadEndpoint}
-          variables={variables}
-        />
-        <EditorContent editor={editor} {...otherProps} />
-        <ImageUploader
-          editor={editor}
-          imageUploadUrl={uploadEndpoint}
-          isOpen={isImageUploaderOpen}
-          unsplashApiKey={editorSecrets.unsplash}
-          uploadConfig={uploadConfig}
-          onClose={() => setIsImageUploaderOpen(false)}
-        />
-      </CharacterCountWrapper>
-    </ErrorWrapper>
+          isActive={isCharacterCountActive}
+        >
+          <Menu
+            addons={addons}
+            defaults={defaults}
+            editor={editor}
+            editorSecrets={editorSecrets}
+            isIndependant={false}
+            mentions={mentions}
+            menuType={menuType}
+            uploadConfig={uploadConfig}
+            uploadEndpoint={uploadEndpoint}
+            variables={variables}
+          />
+          <EditorContent editor={editor} {...otherProps} />
+          <ImageUploader
+            editor={editor}
+            imageUploadUrl={uploadEndpoint}
+            isOpen={isImageUploaderOpen}
+            unsplashApiKey={editorSecrets.unsplash}
+            uploadConfig={uploadConfig}
+            onClose={() => setIsImageUploaderOpen(false)}
+          />
+        </CharacterCountWrapper>
+      </ErrorWrapper>
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes #443 

**Description**

- Fixed: passed the `className` prop to editor wrapper.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
