### PR TITLE
Fixed additional padding below the menu in Firefox

### DIFF
--- a/lib/styles/editor/_menu.scss
+++ b/lib/styles/editor/_menu.scss
@@ -12,7 +12,7 @@
   }
 
   &__wrapper {
-    display: inline-flex;
+    display: flex;
     justify-content: flex-start;
     align-items: center;
     overflow: auto;


### PR DESCRIPTION
Fixes #449 

**Description**

- Fixed: additional padding below the menu in Firefox.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
