### PR TITLE
Removed the className from outer wrapper

### DIFF
--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -109,36 +109,31 @@ const Editor = (
   };
 
   return (
-    <div className={classnames({ [className]: className })}>
-      <ErrorWrapper error={error} isFixedMenuActive={isFixedMenuActive}>
-        <CharacterCountWrapper
+    <ErrorWrapper error={error} isFixedMenuActive={isFixedMenuActive}>
+      <CharacterCountWrapper editor={editor} isActive={isCharacterCountActive}>
+        <Menu
+          addons={addons}
+          defaults={defaults}
           editor={editor}
-          isActive={isCharacterCountActive}
-        >
-          <Menu
-            addons={addons}
-            defaults={defaults}
-            editor={editor}
-            editorSecrets={editorSecrets}
-            isIndependant={false}
-            mentions={mentions}
-            menuType={menuType}
-            uploadConfig={uploadConfig}
-            uploadEndpoint={uploadEndpoint}
-            variables={variables}
-          />
-          <EditorContent editor={editor} {...otherProps} />
-          <ImageUploader
-            editor={editor}
-            imageUploadUrl={uploadEndpoint}
-            isOpen={isImageUploaderOpen}
-            unsplashApiKey={editorSecrets.unsplash}
-            uploadConfig={uploadConfig}
-            onClose={() => setIsImageUploaderOpen(false)}
-          />
-        </CharacterCountWrapper>
-      </ErrorWrapper>
-    </div>
+          editorSecrets={editorSecrets}
+          isIndependant={false}
+          mentions={mentions}
+          menuType={menuType}
+          uploadConfig={uploadConfig}
+          uploadEndpoint={uploadEndpoint}
+          variables={variables}
+        />
+        <EditorContent editor={editor} {...otherProps} />
+        <ImageUploader
+          editor={editor}
+          imageUploadUrl={uploadEndpoint}
+          isOpen={isImageUploaderOpen}
+          unsplashApiKey={editorSecrets.unsplash}
+          uploadConfig={uploadConfig}
+          onClose={() => setIsImageUploaderOpen(false)}
+        />
+      </CharacterCountWrapper>
+    </ErrorWrapper>
   );
 };
 


### PR DESCRIPTION
Fixes #453 

**Description**

- Fixed: removed `className` from outer wrapper.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**


@AbhayVAshokan _a
<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
