### PR TITLE
Added contentClassName prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ export interface EditorProps {
   addons?: string[];
   addonCommands?: Command[];
   className?: string;
+  contentClassName?: string;
   uploadEndpoint?: string;
   uploadConfig?: UppyOptions<Record<string, unknown>>;
   onChange?: (htmlContent: string) => void;

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -33,6 +33,7 @@ const Editor = (
     addons = [],
     addonCommands = [],
     className,
+    contentClassName,
     uploadEndpoint = DIRECT_UPLOAD_ENDPOINT,
     uploadConfig = {},
     onChange = noop,
@@ -83,7 +84,7 @@ const Editor = (
     "fixed-menu-active border": isFixedMenuActive,
     "bubble-menu-active": isBubbleMenuActive,
     "placeholder-active": isPlaceholderActive,
-    [className]: className,
+    [contentClassName]: contentClassName,
   });
 
   const editor = useEditor({
@@ -112,7 +113,7 @@ const Editor = (
   };
 
   return (
-    <div>
+    <div className={classnames({ [className]: className })}>
       {label && (
         <Label data-cy={`${slugify(label)}-editor-label`} required={required}>
           {label}

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -72,6 +72,11 @@ export const EDITOR_PROP_TABLE_ROWS = [
   ],
   [
     "className",
+    "Accepts a string value. Can be used for further customisation of the editor wrapper layout.",
+    `"neeto-editor-content"`,
+  ],
+  [
+    "contentClassName",
     "Accepts a string value. Can be used for further customisation of the editor content layout.",
     `"neeto-editor-content"`,
   ],


### PR DESCRIPTION
Fixes #468 

**Description**

- Added: `contentClassName` prop. This helps pass classes directly to the editor content.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
