### PR TITLE
Misc improvements to formik editor

### DIFF
--- a/lib/components/Common/ErrorWrapper.jsx
+++ b/lib/components/Common/ErrorWrapper.jsx
@@ -6,9 +6,8 @@ import { is } from "ramda";
 import { isNilOrEmpty } from "utils/common";
 
 const ErrorWrapper = ({ error, isFixedMenuActive, children }) => {
-  const wrapperClasses = classnames({
-    "neeto-editor-error": error && isFixedMenuActive,
-  });
+  const isError = !isNilOrEmpty(error) && isFixedMenuActive;
+  const wrapperClasses = classnames({ "neeto-editor-error": isError });
 
   const getErrorMessage = () => {
     if (!error) return null;
@@ -28,12 +27,10 @@ const ErrorWrapper = ({ error, isFixedMenuActive, children }) => {
     return message;
   };
 
-  if (isNilOrEmpty(error)) return children;
-
   return (
     <>
       <div className={wrapperClasses}>{children}</div>
-      <p className="ne-input__error">{getErrorMessage()}</p>
+      {isError && <p className="ne-input__error">{getErrorMessage()}</p>}
     </>
   );
 };

--- a/lib/styles/editor/_editor.scss
+++ b/lib/styles/editor/_editor.scss
@@ -12,6 +12,7 @@
   white-space: pre-wrap;
   padding: 16px;
   color: rgb(var(--neeto-ui-gray-800));
+  background-color: rgb(var(--neeto-ui-white));
 
   &:focus {
     outline: none;

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -1,5 +1,7 @@
 import { isNil, isEmpty } from "ramda";
 
+import { NON_EMPTY_TAGS } from "./constants";
+
 export const slugify = string =>
   string
     .toString()
@@ -30,6 +32,8 @@ export const noop = () => {};
 
 export const isEditorEmpty = htmlContent => {
   if (isNilOrEmpty(htmlContent)) return true;
+
+  if (NON_EMPTY_TAGS.some(tag => htmlContent.includes(tag))) return true;
 
   const element = document.createElement("div");
   element.innerHTML = htmlContent;

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,0 +1,1 @@
+export const NON_EMPTY_TAGS = ["img", "iframe"];


### PR DESCRIPTION
Fixes #472 

**Description**

- Fixed: prevented the _ErrorWrapper_ component from re-rendering the whole _Editor_ within formik.
- Added: updated `isEditorEmpty` method to handle `img` and `iframe` tags.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
