### PR TITLE
Added `useEditorStore` hook to obtain the`editor` instance

### DIFF
--- a/alias.js
+++ b/alias.js
@@ -10,6 +10,7 @@ module.exports = {
   contexts: absolutePath("contexts"),
   hooks: absolutePath("hooks"),
   reducers: absolutePath("reducers"),
+  stores: absolutePath("stores"),
   utils: absolutePath("utils"),
   neetoicons: "@bigbinary/neeto-icons",
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,7 @@ export interface EditorProps {
   keyboardShortcuts?: KeyboardShortcuts;
   error?: string;
   config?: Config;
-  editorContextKey?: string;
+  editorKey?: string;
   [otherProps: string]: any;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,6 +103,7 @@ export interface EditorProps {
   keyboardShortcuts?: KeyboardShortcuts;
   error?: string;
   config?: Config;
+  editorContextKey?: string;
   [otherProps: string]: any;
 }
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -21,6 +21,8 @@
       "hooks": ["hooks"],
       "reducers/*": ["reducers/*"],
       "reducers": ["reducers"],
+      "stores/*": ["stores/*"],
+      "stores": ["stores"],
       "routes/*": ["common/routes/*"],
       "routes": ["common/routes"],
       "translations/*": ["translations/*"],

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -52,7 +52,7 @@ const Editor = (
     keyboardShortcuts = [],
     error = null,
     config = {},
-    editorContextKey = "editor",
+    editorKey,
     ...otherProps
   },
   ref
@@ -109,7 +109,7 @@ const Editor = (
 
   /* Make editor object available to the parent */
   useImperativeHandle(ref, () => ({ editor }));
-  setEditor({ [editorContextKey]: editor });
+  editorKey && setEditor({ [editorKey]: editor });
 
   // https://github.com/ueberdosis/tiptap/issues/1451#issuecomment-953348865
   EditorView.prototype.updateState = function updateState(state) {

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -3,11 +3,13 @@ import React, { useImperativeHandle, useState } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import classnames from "classnames";
 import { EditorView } from "prosemirror-view";
+import { prop } from "ramda";
 
 import { DIRECT_UPLOAD_ENDPOINT } from "common/constants";
 import ErrorWrapper from "components/Common/ErrorWrapper";
 import Label from "components/Common/Label";
 import useEditorWarnings from "hooks/useEditorWarnings";
+import useEditorStore from "stores/useEditorStore";
 import { noop, slugify } from "utils/common";
 
 import { DEFAULT_EDITOR_OPTIONS } from "./constants";
@@ -50,6 +52,7 @@ const Editor = (
     keyboardShortcuts = [],
     error = null,
     config = {},
+    editorContextKey = "editor",
     ...otherProps
   },
   ref
@@ -59,6 +62,7 @@ const Editor = (
   const isSlashCommandsActive = !hideSlashCommands;
   const isPlaceholderActive = !!placeholder;
   const [isImageUploaderOpen, setIsImageUploaderOpen] = useState(false);
+  const setEditor = useEditorStore(prop("setEditor"));
 
   const customExtensions = useCustomExtensions({
     placeholder,
@@ -75,9 +79,6 @@ const Editor = (
     openImageUploader: () => setIsImageUploaderOpen(true),
   });
   useEditorWarnings({ initialValue });
-
-  /* Make editor object available to the parent */
-  useImperativeHandle(ref, () => ({ editor }));
 
   const editorClasses = classnames("neeto-editor", {
     "slash-active": isSlashCommandsActive && !isPlaceholderActive,
@@ -105,6 +106,10 @@ const Editor = (
     onFocus,
     onBlur,
   });
+
+  /* Make editor object available to the parent */
+  useImperativeHandle(ref, () => ({ editor }));
+  setEditor({ [editorContextKey]: editor });
 
   // https://github.com/ueberdosis/tiptap/issues/1451#issuecomment-953348865
   EditorView.prototype.updateState = function updateState(state) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+import useEditorStore from "stores/useEditorStore";
 import { isEditorEmpty } from "utils/common";
 
 import Editor from "./components/Editor";
@@ -5,4 +6,4 @@ import Menu from "./components/Editor/Menu";
 import EditorContent from "./components/EditorContent";
 import "./index.scss";
 
-export { Editor, EditorContent, Menu, isEditorEmpty };
+export { Editor, EditorContent, Menu, isEditorEmpty, useEditorStore };

--- a/lib/stores/useEditorStore.js
+++ b/lib/stores/useEditorStore.js
@@ -1,0 +1,8 @@
+import create from "zustand";
+
+const useEditorStore = create(set => ({
+  editor: null,
+  setEditor: set,
+}));
+
+export default useEditorStore;

--- a/lib/stores/useEditorStore.js
+++ b/lib/stores/useEditorStore.js
@@ -1,8 +1,5 @@
 import create from "zustand";
 
-const useEditorStore = create(set => ({
-  editor: null,
-  setEditor: set,
-}));
+const useEditorStore = create(set => ({ setEditor: set }));
 
 export default useEditorStore;

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "webpack": "5.73.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.9.3",
-    "yup": "0.32.11"
+    "yup": "0.32.11",
+    "zustand": "4.1.4"
   },
   "peerDependencies": {
     "formik": "2.2.9",

--- a/stories/API-Reference/All-props.stories.mdx
+++ b/stories/API-Reference/All-props.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, ArgsTable } from "@storybook/addon-docs";
+import { EDITOR_PROPS } from "./constants";
+import { buildArgValues } from "../utils";
 import { Editor } from "../../lib";
-import { ARG_VALUES } from "./constants";
 
 <Meta
   title="API Reference/All Props"
@@ -14,7 +15,7 @@ import { ARG_VALUES } from "./constants";
       },
     },
   }}
-  argTypes={ARG_VALUES}
+  argTypes={buildArgValues(EDITOR_PROPS)}
 />
 
 # **Props**

--- a/stories/API-Reference/Editor-API.stories.mdx
+++ b/stories/API-Reference/Editor-API.stories.mdx
@@ -32,7 +32,7 @@ methods that can be access the editor content.
 #### **Usage**
 
 ```js
-editorRef.current.editor.methodName;
+editor.methodName;
 ```
 
 Refer [https://tiptap.dev/api/editor](https://tiptap.dev/api/editor) for the
@@ -48,13 +48,13 @@ commands to control the editor content.
 #### **Usage**
 
 ```js
-editorRef.current.editor.commands.commandName();
+editor.commands.commandName();
 ```
 
 You can also combine multiple commands in a single call.
 
 ```js
-editorRef.current.editor.chain().command1().command2().run();
+editor.chain().command1().command2().run();
 ```
 
 Refer [https://tiptap.dev/api/commands](https://tiptap.dev/api/commands) for the

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -29,7 +29,7 @@ export const EDITOR_METHODS_TABLE_ROWS = [
   ],
 ];
 
-export const EDITOR_PROP_TABLE_ROWS = [
+export const EDITOR_PROPS = [
   [
     "ref",
     "Accepts a React reference. This reference can be used to access TipTap's inbuilt editor methods, such as getHTML().",
@@ -183,18 +183,9 @@ export const EDITOR_PROP_TABLE_ROWS = [
     }
     `,
   ],
+  [
+    "editorKey",
+    "Accepts a string. If provided, this can be used to use the `editor` instance using the `useEditorStore` hook.",
+    `NEETO_KB_EDITOR`,
+  ],
 ];
-
-export const ARG_VALUES = EDITOR_PROP_TABLE_ROWS.reduce((acc, value) => {
-  return {
-    ...acc,
-    [value[0]]: {
-      name: value[0],
-      description: value[1],
-      control: false,
-      table: {
-        defaultValue: { summary: value[2] },
-      },
-    },
-  };
-}, {});

--- a/stories/Examples/Independant-menu-component.stories.mdx
+++ b/stories/Examples/Independant-menu-component.stories.mdx
@@ -1,0 +1,50 @@
+import { Meta, Canvas } from "@storybook/addon-docs";
+import IndependantMenuComponentDemo from "./IndependantMenuComponentDemo";
+import { Editor } from "../../lib";
+
+<Meta
+  title="Examples/Independent menu component"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+  component={Editor}
+/>
+
+# Independent menu component
+
+<Canvas>
+  <IndependantMenuComponentDemo />
+</Canvas>
+
+## Usage
+
+```jsx
+import React from "react";
+
+import { Editor, Menu, useEditorStore } from "@bigbinary/neeto-editor";
+import { prop } from "ramda";
+
+const App = () => {
+  const EDITOR_KEY = "NEETO_EDITOR_KEY";
+  const editor = useEditorStore(prop(EDITOR_KEY));
+
+  return (
+    <div className="space-y-4">
+      <Menu editor={editor} />
+      <h2>Other components</h2>
+      <Editor
+        autoFocus
+        contentClassName="border"
+        editorKey={EDITOR_KEY}
+        initialValue="<p>Hello World</p>"
+        menuType="none"
+      />
+    </div>
+  );
+};
+
+export default App;
+```

--- a/stories/Examples/IndependantMenuComponentDemo.jsx
+++ b/stories/Examples/IndependantMenuComponentDemo.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { prop } from "ramda";
+
+import { Editor, Menu, useEditorStore } from "../../lib";
+
+const IndependantMenuComponentDemo = () => {
+  const EDITOR_KEY = "NEETO_EDITOR_KEY";
+  const editor = useEditorStore(prop(EDITOR_KEY));
+
+  return (
+    <div className="space-y-4">
+      <Menu editor={editor} />
+      <h2>Other components</h2>
+      <Editor
+        autoFocus
+        contentClassName="border"
+        editorKey={EDITOR_KEY}
+        initialValue="<p>Hello World</p>"
+        menuType="none"
+      />
+    </div>
+  );
+};
+
+export default IndependantMenuComponentDemo;

--- a/stories/Examples/Menu.stories.mdx
+++ b/stories/Examples/Menu.stories.mdx
@@ -31,4 +31,5 @@ export const Template = args => <Menu {...args} />;
   <ArgsTable story="Menu" />
 </div>
 
-www.google.com shows an example with the `Menu` component in action.
+[Independant menu component](https://neeto-editor.onrender.com/?path=/docs/examples-independent-menu-component--page)
+section shows an example with the `Menu` component in action.

--- a/stories/Examples/Menu.stories.mdx
+++ b/stories/Examples/Menu.stories.mdx
@@ -1,0 +1,34 @@
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { MENU_PROPS } from "./constants";
+import { Editor, Menu } from "../../lib";
+import { buildArgValues } from "../utils";
+
+<Meta
+  title="Walkthroughs/Menu"
+  parameters={{
+    viewMode: "docs",
+    layout: "padded",
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+  component={Editor}
+  argTypes={buildArgValues(MENU_PROPS)}
+/>
+
+# Use Menu as an independant component
+
+Sometimes the editor's menu needs to be rendered separate from the editor
+content. In such cases use the `Menu` component.
+
+### Props
+
+export const Template = args => <Menu {...args} />;
+
+<Story name="Menu"> {Template.bind({})}</Story>
+
+<div id="hide-controls-column">
+  <ArgsTable story="Menu" />
+</div>
+
+www.google.com shows an example with the `Menu` component in action.

--- a/stories/Examples/constants.js
+++ b/stories/Examples/constants.js
@@ -1,0 +1,61 @@
+export const MENU_PROPS = [
+  [
+    "editor",
+    "Accepts the instance of editor to which this this Menu component is associated with.",
+    "editor",
+  ],
+  [
+    "menuType",
+    "Describes the menu type that editor should display. value should be one of ['fixed', 'bubble', 'none']. Defaults to 'fixed'.",
+    `"bubble"`,
+  ],
+  [
+    "defaults",
+    "Accepts an array of strings, each corresponding to the name of a default option.",
+    `["h1", "h2", "h3", "h4", "h5", "h6"]`,
+  ],
+  [
+    "addons",
+    "Accepts an array of strings, each corresponding to the name of an addon.",
+    `["highlight", "emoji", "code-block", "block-quote", "image-upload", "divider", "video-embed", "paste-unformatted"]`,
+  ],
+  [
+    "className",
+    "Accepts a string value. Can be used for further customisation of the editor wrapper layout.",
+    `"neeto-editor-content"`,
+  ],
+  [
+    "uploadEndpoint",
+    "Accepts an URL endpoint string. This URL will be used for XHR image uploads.",
+    `"/api/direct_uploads"`,
+  ],
+  [
+    "uploadConfig",
+    "Accepts an object. This object will be used to configure the image uploader.",
+    `{
+      autoProceed: true,
+      allowMultipleUploads: false,
+      restrictions: {
+        maxFileSize: 1048576,
+        allowedFileTypes: [".jpg"]
+      },
+    }`,
+  ],
+  [
+    "variables",
+    "Accepts an array of variable suggestions.",
+    `[{ label: "Subdomain", key: "subdomain" }]`,
+  ],
+  [
+    "mentions",
+    "Accepts an array of mention suggestions.",
+    `[{ name: "Oliver Smith", key: "oliver-smith", imageUrl: "url" }]`,
+  ],
+  [
+    "editorSecrets",
+    "Accepts an object. Use this prop to pass down API keys and other secrets.",
+    `{
+      unsplash: "<unsplash-api-key>"
+     }`,
+  ],
+];

--- a/stories/Walkthroughs/Editor-instance.stories.mdx
+++ b/stories/Walkthroughs/Editor-instance.stories.mdx
@@ -1,0 +1,45 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { Editor } from "../../lib";
+
+<Meta
+  title="Walkthroughs/Editor instance"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+  component={Editor}
+/>
+
+# Access the editor instance
+
+You need to access the `editor` instance to call the methods specified in the
+[Editor API](https://neeto-editor.onrender.com/?path=/docs/api-reference-editor-api--page)
+section. This is possible using the `useEditorStore` hook. Pass a constant
+string value to the `editorKey` prop to the `Editor` component and use this key
+to access the `editor` instance.
+
+### Usage
+
+```jsx
+import React from "react";
+
+import { Editor, useEditorStore } from "@bigbinary/neeto-editor";
+import { prop } from "ramda";
+
+const EDITOR_KEY = "NEETO_EDITOR_KEY";
+
+const App = () => {
+  const editor = useEditorStore(prop(EDITOR_KEY));
+
+  const handleClearEditor = () => editor.commands.clearContent();
+
+  return (
+    <div>
+      <Editor editorKey={EDITOR_KEY} />
+      <button onClick={handleClearEditor}>Clear content</button>
+    </div>
+  );
+};
+```

--- a/stories/Walkthroughs/Formik.stories.mdx
+++ b/stories/Walkthroughs/Formik.stories.mdx
@@ -5,7 +5,7 @@ import FormikEditor from "../../lib/components/Editor/FormikEditor";
 <Meta
   title="Walkthroughs/Formik"
   parameters={{
-    viewMode: "padded",
+    viewMode: "docs",
     previewTabs: {
       canvas: { hidden: true },
     },

--- a/stories/Walkthroughs/Formik.stories.mdx
+++ b/stories/Walkthroughs/Formik.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { Meta, Canvas } from "@storybook/addon-docs";
 import FormikEditorDemo from "./FormikEditorDemo";
 import FormikEditor from "../../lib/components/Editor/FormikEditor";
 

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -1,0 +1,15 @@
+export const buildArgValues = rows =>
+  rows.reduce(
+    (acc, value) => ({
+      ...acc,
+      [value[0]]: {
+        name: value[0],
+        description: value[1],
+        control: false,
+        table: {
+          defaultValue: { summary: value[2] },
+        },
+      },
+    }),
+    {}
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12878,6 +12878,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -13519,6 +13524,13 @@ yup@0.32.11:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+zustand@4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.4.tgz#b0286da4cc9edd35e91c96414fa54bfa4652a54d"
+  integrity sha512-k2jVOlWo8p4R83mQ+/uyB8ILPO2PCJOf+QVjcL+1PbMCk1w5OoPYpAIxy9zd93FSfmJqoH6lGdwzzjwqJIRU5A==
+  dependencies:
+    use-sync-external-store "1.2.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Fixes #474 

**Description**

- Added: `useEditorStore` hook to obtain the editor instance.
- Added: `editorKey` prop to map the editor instance to the associated `Editor` component.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
