### PR TITLE
Moved FormikEditor to the main bundle

### DIFF
--- a/lib/components/Editor/FormikEditor.jsx
+++ b/lib/components/Editor/FormikEditor.jsx
@@ -10,7 +10,6 @@ const FormikEditor = ({ name, ...otherProps }, ref) => (
   <Field name={name}>
     {({ field, form, meta }) => (
       <Editor
-        {...field}
         error={meta.touched ? meta.error : ""}
         initialValue={field.value}
         ref={ref}

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useState } from "react";
+import React, { useEffect, useImperativeHandle, useState } from "react";
 
 import { useEditor, EditorContent } from "@tiptap/react";
 import classnames from "classnames";
@@ -109,7 +109,9 @@ const Editor = (
 
   /* Make editor object available to the parent */
   useImperativeHandle(ref, () => ({ editor }));
-  editorKey && setEditor({ [editorKey]: editor });
+  useEffect(() => {
+    if (editorKey) setEditor({ [editorKey]: editor });
+  }, [editor, editorKey, setEditor]);
 
   // https://github.com/ueberdosis/tiptap/issues/1451#issuecomment-953348865
   EditorView.prototype.updateState = function updateState(state) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,16 @@ import useEditorStore from "stores/useEditorStore";
 import { isEditorEmpty } from "utils/common";
 
 import Editor from "./components/Editor";
+import FormikEditor from "./components/Editor/FormikEditor";
 import Menu from "./components/Editor/Menu";
 import EditorContent from "./components/EditorContent";
 import "./index.scss";
 
-export { Editor, EditorContent, Menu, isEditorEmpty, useEditorStore };
+export {
+  Editor,
+  EditorContent,
+  Menu,
+  isEditorEmpty,
+  useEditorStore,
+  FormikEditor,
+};

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -33,7 +33,7 @@ export const noop = () => {};
 export const isEditorEmpty = htmlContent => {
   if (isNilOrEmpty(htmlContent)) return true;
 
-  if (NON_EMPTY_TAGS.some(tag => htmlContent.includes(tag))) return true;
+  if (NON_EMPTY_TAGS.some(tag => htmlContent.includes(tag))) return false;
 
   const element = document.createElement("div");
   element.innerHTML = htmlContent;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "main": "./index.js",
   "module": "./index.js",
-  "types": "./index.d.ts",
+  "types": "./types.d.ts",
   "description": "neetoEditor is the library that drives the rich text experience in all neeto products built at BigBinary",
   "keywords": [
     "ui",
@@ -13,9 +13,7 @@
   ],
   "files": [
     "index.js",
-    "formik.js",
-    "index.d.ts",
-    "formik.d.ts"
+    "types.d.ts"
   ],
   "author": "BigBinary",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,17 +54,6 @@ export default [
     plugins,
   },
   {
-    input: "./lib/components/Editor/FormikEditor.jsx",
-    output: {
-      file: "./formik.js",
-      format: "esm",
-      sourcemap: false,
-      name: "neetoEditor",
-      assetFileNames: "[name][extname]",
-    },
-    plugins,
-  },
-  {
     input: "./lib/styles/editor-output.scss",
     output: {
       dir: `${__dirname}/dist`,

--- a/stories/Getting-started.stories.mdx
+++ b/stories/Getting-started.stories.mdx
@@ -59,7 +59,7 @@ import { isEditoryEmpty } from "@bigbinary/neeto-editor";
 Use the `FormikEditor` component if it is used as a formik input component.
 
 ```jsx
-import FormikEditor from "@bigbinary/neeto-editor/formik";
+import FormikEditor from "@bigbinary/neeto-editor";
 ```
 
 ### **Local development**

--- a/stories/Walkthroughs/Formik.stories.mdx
+++ b/stories/Walkthroughs/Formik.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from "@storybook/addon-docs";
 import FormikEditorDemo from "./FormikEditorDemo";
-import FormikEditor from "../../lib/components/Editor/FormikEditor";
+import FormikEditor from "../../lib";
 
 <Meta
   title="Walkthroughs/Formik"
@@ -24,7 +24,7 @@ formik.
 import React from "react";
 
 import { isEditorEmpty } from "@bigbinary/neeto-editor";
-import FormikEditor from "@bigbinary/neeto-editor/formik";
+import FormikEditor from "@bigbinary/neeto-editor";
 import { Formik, Form } from "formik";
 import * as yup from "yup";
 

--- a/stories/Walkthroughs/FormikEditorDemo.jsx
+++ b/stories/Walkthroughs/FormikEditorDemo.jsx
@@ -3,9 +3,8 @@ import React from "react";
 import { Formik, Form } from "formik";
 import * as yup from "yup";
 
-import { isEditorEmpty } from "../../lib";
+import { isEditorEmpty, FormikEditor } from "../../lib";
 import Button from "../../lib/components/Common/Button";
-import FormikEditor from "../../lib/components/Editor/FormikEditor";
 
 const INITIAL_VALUES = {
   description: "<p></p>",

--- a/types.d.ts
+++ b/types.d.ts
@@ -75,7 +75,7 @@ interface MenuProps {
   className?: string;
 }
 
-export interface EditorProps {
+interface EditorProps {
   initialValue?: string;
   menuType?: "fixed" | "bubble" | "none";
   label?: string;
@@ -107,7 +107,13 @@ export interface EditorProps {
   [otherProps: string]: any;
 }
 
+interface FormikEditorProps extends EditorProps {
+  name: string;
+}
+
 export function Editor(props: EditorProps): JSX.Element;
+
+export function FormikEditor(props: FormikEditorProps): JSX.Element;
 
 export function EditorContent(props: {
   content?: string;


### PR DESCRIPTION
Fixes #issue-number

**Description**

- Changed: **BREAKING** Moved _FormikEdotor_ component to the main bundle. It needs to be imported as `import { FormikEditor } from "@bigbinary/neeto-editor";`.
- Fixed: issues with `isEditorEmpty` method which prevented it from recognizing tags.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
minor _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
