### PR TITLE
Removed wrapper div from images

### DIFF
--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -68,14 +68,11 @@ const ImageExtension = Node.create({
   renderHTML({ node, HTMLAttributes }) {
     const { align, src, figheight, figwidth } = node.attrs;
 
-    const wrapperAttrs = {
-      class: `neeto-editor__image-wrapper neeto-editor__image--${align}`,
-    };
-
     const linkAttrs = {
       href: src,
       target: "_blank",
       rel: "noopener noreferrer",
+      class: `neeto-editor__image-wrapper neeto-editor__image--${align}`,
     };
 
     const resizeAttrs = {
@@ -84,27 +81,23 @@ const ImageExtension = Node.create({
     };
 
     return [
-      "div",
-      wrapperAttrs,
+      "a",
+      linkAttrs,
       [
-        "a",
-        linkAttrs,
+        "figure",
+        this.options.HTMLAttributes,
         [
-          "figure",
-          this.options.HTMLAttributes,
+          "div",
+          resizeAttrs,
           [
-            "div",
-            resizeAttrs,
-            [
-              "img",
-              mergeAttributes(HTMLAttributes, {
-                draggable: false,
-                contenteditable: false,
-              }),
-            ],
+            "img",
+            mergeAttributes(HTMLAttributes, {
+              draggable: false,
+              contenteditable: false,
+            }),
           ],
-          ["figcaption", 0],
         ],
+        ["figcaption", 0],
       ],
     ];
   },

--- a/lib/styles/editor/_editor-content.scss
+++ b/lib/styles/editor/_editor-content.scss
@@ -170,10 +170,8 @@
     }
   }
 
-  a {
-    color: unset !important;
-    font-weight: normal !important;
-  }
+  color: unset !important;
+  font-weight: normal !important;
 }
 
 .neeto-editor__image--left {


### PR DESCRIPTION
Fixes #480 

**Description**

- Removed: unnecessary wrapper `div` from images. This enables easy updation of editor to latest version.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
