### PR TITLE
Removed useEditorStore hook and editorKey prop

### DIFF
--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -1,15 +1,13 @@
-import React, { useEffect, useImperativeHandle, useState } from "react";
+import React, { useImperativeHandle, useState } from "react";
 
 import { useEditor, EditorContent } from "@tiptap/react";
 import classnames from "classnames";
 import { EditorView } from "prosemirror-view";
-import { prop } from "ramda";
 
 import { DIRECT_UPLOAD_ENDPOINT } from "common/constants";
 import ErrorWrapper from "components/Common/ErrorWrapper";
 import Label from "components/Common/Label";
 import useEditorWarnings from "hooks/useEditorWarnings";
-import useEditorStore from "stores/useEditorStore";
 import { noop, slugify } from "utils/common";
 
 import { DEFAULT_EDITOR_OPTIONS } from "./constants";
@@ -52,7 +50,6 @@ const Editor = (
     keyboardShortcuts = [],
     error = null,
     config = {},
-    editorKey,
     ...otherProps
   },
   ref
@@ -62,7 +59,6 @@ const Editor = (
   const isSlashCommandsActive = !hideSlashCommands;
   const isPlaceholderActive = !!placeholder;
   const [isImageUploaderOpen, setIsImageUploaderOpen] = useState(false);
-  const setEditor = useEditorStore(prop("setEditor"));
 
   const customExtensions = useCustomExtensions({
     placeholder,
@@ -109,9 +105,6 @@ const Editor = (
 
   /* Make editor object available to the parent */
   useImperativeHandle(ref, () => ({ editor }));
-  useEffect(() => {
-    if (editorKey) setEditor({ [editorKey]: editor });
-  }, [editor, editorKey, setEditor]);
 
   // https://github.com/ueberdosis/tiptap/issues/1451#issuecomment-953348865
   EditorView.prototype.updateState = function updateState(state) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-import useEditorStore from "stores/useEditorStore";
 import { isEditorEmpty } from "utils/common";
 
 import Editor from "./components/Editor";
@@ -7,11 +6,4 @@ import Menu from "./components/Editor/Menu";
 import EditorContent from "./components/EditorContent";
 import "./index.scss";
 
-export {
-  Editor,
-  EditorContent,
-  Menu,
-  isEditorEmpty,
-  useEditorStore,
-  FormikEditor,
-};
+export { Editor, EditorContent, Menu, isEditorEmpty, FormikEditor };

--- a/lib/stores/useEditorStore.js
+++ b/lib/stores/useEditorStore.js
@@ -1,5 +1,0 @@
-import create from "zustand";
-
-const useEditorStore = create(set => ({ setEditor: set }));
-
-export default useEditorStore;

--- a/package.json
+++ b/package.json
@@ -115,8 +115,7 @@
     "webpack": "5.73.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.9.3",
-    "yup": "0.32.11",
-    "zustand": "4.1.4"
+    "yup": "0.32.11"
   },
   "peerDependencies": {
     "formik": "2.2.9",

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -33,7 +33,7 @@ export const EDITOR_PROPS = [
   [
     "ref",
     "Accepts a React reference. This reference can be used to access TipTap's inbuilt editor methods, such as getHTML().",
-    `React.createRef()`,
+    "React.createRef()",
   ],
   [
     "initialValue",
@@ -53,7 +53,7 @@ export const EDITOR_PROPS = [
   [
     "hideSlashCommands",
     "Accepts a boolean value. When true, the Slash Commands menu will be hidden.",
-    `true`,
+    "true",
   ],
   [
     "defaults",
@@ -135,7 +135,7 @@ export const EDITOR_PROPS = [
   [
     "extensions",
     "Accepts an array of TipTap extensions. When provided, this will be combined with the default set of extensions.",
-    `[Bold, Color]`,
+    "[Bold, Color]",
   ],
   [
     "editorSecrets",
@@ -182,10 +182,5 @@ export const EDITOR_PROPS = [
       focus: { mode: "deepest" }
     }
     `,
-  ],
-  [
-    "editorKey",
-    "Accepts a string. If provided, this can be used to use the `editor` instance using the `useEditorStore` hook.",
-    `NEETO_KB_EDITOR`,
   ],
 ];

--- a/stories/Examples/Independant-menu-component.stories.mdx
+++ b/stories/Examples/Independant-menu-component.stories.mdx
@@ -22,14 +22,15 @@ import { Editor } from "../../lib";
 ## Usage
 
 ```jsx
-import React from "react";
+import React, { useCallback, useState } from "react";
 
-import { Editor, Menu, useEditorStore } from "@bigbinary/neeto-editor";
-import { prop } from "ramda";
+import { Editor, Menu } from "@bigbinary/neeto-editor";
 
-const App = () => {
-  const EDITOR_KEY = "NEETO_EDITOR_KEY";
-  const editor = useEditorStore(prop(EDITOR_KEY));
+const IndependantMenuComponent = () => {
+  const [editor, setEditor] = useState(null);
+  const editorRef = useCallback(node => {
+    if (node) setEditor(node.editor);
+  }, []);
 
   return (
     <div className="space-y-4">
@@ -38,13 +39,18 @@ const App = () => {
       <Editor
         autoFocus
         contentClassName="border"
-        editorKey={EDITOR_KEY}
         initialValue="<p>Hello World</p>"
         menuType="none"
+        ref={editorRef}
       />
     </div>
   );
 };
 
-export default App;
+export default IndependantMenuComponent;
 ```
+
+> You might have noticed a different syntax to declare a `ref`. For this case,
+> we use the callback version of syntax to initialize `editorRef`. This is an
+> elegant way of listening to the changes in the `ref` value and triggering a
+> state change to render the `Menu` compnonent.

--- a/stories/Examples/IndependantMenuComponentDemo.jsx
+++ b/stories/Examples/IndependantMenuComponentDemo.jsx
@@ -1,12 +1,12 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 
-import { prop } from "ramda";
+import { Editor, Menu } from "../../lib";
 
-import { Editor, Menu, useEditorStore } from "../../lib";
-
-const IndependantMenuComponentDemo = () => {
-  const EDITOR_KEY = "NEETO_EDITOR_KEY";
-  const editor = useEditorStore(prop(EDITOR_KEY));
+const IndependantMenuComponent = () => {
+  const [editor, setEditor] = useState(null);
+  const editorRef = useCallback(node => {
+    if (node) setEditor(node.editor);
+  }, []);
 
   return (
     <div className="space-y-4">
@@ -15,12 +15,12 @@ const IndependantMenuComponentDemo = () => {
       <Editor
         autoFocus
         contentClassName="border"
-        editorKey={EDITOR_KEY}
         initialValue="<p>Hello World</p>"
         menuType="none"
+        ref={editorRef}
       />
     </div>
   );
 };
 
-export default IndependantMenuComponentDemo;
+export default IndependantMenuComponent;

--- a/stories/Walkthroughs/Editor-instance.stories.mdx
+++ b/stories/Walkthroughs/Editor-instance.stories.mdx
@@ -16,28 +16,27 @@ import { Editor } from "../../lib";
 
 You need to access the `editor` instance to call the methods specified in the
 [Editor API](https://neeto-editor.onrender.com/?path=/docs/api-reference-editor-api--page)
-section. This is possible using the `useEditorStore` hook. Pass a constant
-string value to the `editorKey` prop to the `Editor` component and use this key
-to access the `editor` instance.
+section. This is possible by passing a `ref` to the `Editor` or `FormikEditor`
+component. If the `ref` is named as `editorRef`, then the `editor` instance can
+be accessed as `editorRef.current.editor`.
 
 ### Usage
 
 ```jsx
-import React from "react";
+import React, { useRef } from "react";
 
-import { Editor, useEditorStore } from "@bigbinary/neeto-editor";
+import { Editor } from "@bigbinary/neeto-editor";
 import { prop } from "ramda";
 
-const EDITOR_KEY = "NEETO_EDITOR_KEY";
-
 const App = () => {
-  const editor = useEditorStore(prop(EDITOR_KEY));
+  const editorRef = useRef(null);
 
-  const handleClearEditor = () => editor.commands.clearContent();
+  const handleClearEditor = () =>
+    editorRef.current.editor.commands.clearContent();
 
   return (
     <div>
-      <Editor editorKey={EDITOR_KEY} />
+      <Editor ref={editorRef} />
       <button onClick={handleClearEditor}>Clear content</button>
     </div>
   );

--- a/types.d.ts
+++ b/types.d.ts
@@ -103,7 +103,6 @@ interface EditorProps {
   keyboardShortcuts?: KeyboardShortcuts;
   error?: string;
   config?: Config;
-  editorKey?: string;
   [otherProps: string]: any;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12878,11 +12878,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-sync-external-store@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -13524,13 +13519,6 @@ yup@0.32.11:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
-
-zustand@4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.4.tgz#b0286da4cc9edd35e91c96414fa54bfa4652a54d"
-  integrity sha512-k2jVOlWo8p4R83mQ+/uyB8ILPO2PCJOf+QVjcL+1PbMCk1w5OoPYpAIxy9zd93FSfmJqoH6lGdwzzjwqJIRU5A==
-  dependencies:
-    use-sync-external-store "1.2.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Fixes #482 

**Description**

- Removed: **BREAKING** the _useEditorStore_ hook to access the editor instance.
- Removed: **BREAKING** the `editorKey` prop to access the _useEditorStore_ hook.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
minor _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
