### PR TITLE
Fixed left alignment of figure captions

### DIFF
--- a/lib/styles/editor/_editor-content.scss
+++ b/lib/styles/editor/_editor-content.scss
@@ -159,6 +159,11 @@
     text-align: center;
     font-size: var(--neeto-ui-text-sm);
     font-weight: var(--neeto-ui-font-normal);
+
+    a {
+      display: inline-block;
+      text-align: center;
+    }
   }
 
   figcaption.is-empty {


### PR DESCRIPTION
Fixes #485 

**Description**

- Fixed: prevented figure captions from aligning to the left.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
