### PR TITLE
Added ability to add additional menu items through addonCommands prop

### DIFF
--- a/lib/components/Common/MenuButton.jsx
+++ b/lib/components/Common/MenuButton.jsx
@@ -14,7 +14,7 @@ import ToolTip from "./ToolTip";
 
 const MenuButton = ({
   icon: Icon,
-  iconActive = true,
+  iconActive = false,
   tooltipProps,
   highlight = false,
   color,

--- a/lib/components/Editor/CustomExtensions/FixedMenu/index.jsx
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/index.jsx
@@ -9,7 +9,11 @@ import EmojiOption from "./EmojiOption";
 import FontSizeOption from "./FontSizeOption";
 import LinkOption from "./LinkOption";
 import Separator from "./Separator";
-import { buildMenuOptions, renderOptionButton } from "./utils";
+import {
+  buildMenuOptions,
+  buildOptionsFromAddonCommands,
+  renderOptionButton,
+} from "./utils";
 
 import Mentions from "../Mention";
 import Variables from "../Variable";
@@ -20,6 +24,7 @@ const FixedMenu = ({
   mentions,
   variables,
   setIsImageUploadOpen,
+  addonCommands,
   isIndependant,
   className,
 }) => {
@@ -38,6 +43,10 @@ const FixedMenu = ({
   const isFontSizeActive = fontSizeOptions.length > 0;
   const isEmojiActive = options.includes(EDITOR_OPTIONS.EMOJI);
   const isLinkActive = options.includes(EDITOR_OPTIONS.LINK);
+  const addonCommandOptions = buildOptionsFromAddonCommands({
+    editor,
+    commands: addonCommands,
+  });
 
   return (
     <div
@@ -58,6 +67,7 @@ const FixedMenu = ({
         {isLinkActive && <LinkOption editor={editor} />}
         {miscOptions.map(renderOptionButton)}
         <Mentions editor={editor} mentions={mentions} />
+        {addonCommandOptions.map(renderOptionButton)}
         <div className="neeto-editor-fixed-menu__right-options">
           {rightOptions.map(renderOptionButton)}
         </div>

--- a/lib/components/Editor/CustomExtensions/FixedMenu/utils.jsx
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/utils.jsx
@@ -41,3 +41,13 @@ export const renderOptionButton = ({
     onClick={command}
   />
 );
+
+export const buildOptionsFromAddonCommands = ({ editor, commands }) => {
+  const { to } = editor.state.selection;
+
+  return commands.map(option => ({
+    ...option,
+    active: option.active?.({ editor }),
+    command: () => option.command?.({ editor, range: { from: to, to } }),
+  }));
+};

--- a/lib/components/Editor/Menu/index.jsx
+++ b/lib/components/Editor/Menu/index.jsx
@@ -19,6 +19,7 @@ const Menu = ({
   uploadConfig = {},
   mentions = [],
   variables = [],
+  addonCommands = [],
   isIndependant = true,
   className,
 }) => {
@@ -31,6 +32,7 @@ const Menu = ({
     <>
       {isFixedMenuActive && (
         <FixedMenu
+          addonCommands={addonCommands}
           className={classnames({ [className]: className })}
           editor={editor}
           isIndependant={isIndependant}

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -125,6 +125,7 @@ const Editor = (
           isActive={isCharacterCountActive}
         >
           <Menu
+            addonCommands={addonCommands}
             addons={addons}
             defaults={defaults}
             editor={editor}

--- a/types.d.ts
+++ b/types.d.ts
@@ -19,6 +19,7 @@ interface Command {
   Icon: Function;
   description?: string;
   optionName: string;
+  active?: ({ editor: TiptapEditor }) => boolean;
   command?: (props: { editor: TiptapEditor; range: Range }) => void;
   items?: Command[];
 }
@@ -71,6 +72,7 @@ interface MenuProps {
   uploadConfig?: UppyOptions<Record<string, unknown>>;
   mentions?: Mention[];
   variables?: Variable[];
+  addonCommands?: Command[];
   isIndependant?: boolean;
   className?: string;
 }


### PR DESCRIPTION
Fixes #483 

**Description**

- Added: `addonCommands` prop to the _Menu_ component. Each addon command will add its corresponding option in the menu.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@karthiknmenon _a can you please take a look: https://app.usebubbles.com/wyBKvi7KDuT2MAQm6CYrCJ/untitled-bubble
minor _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
