### PR TITLE
Failing action will not abort publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,7 @@ jobs:
         shell: bash
 
       - name: Update Changelog
+        continue-on-error: true
         uses: bigbinary/changelog-updater-action@v2
         with:
           latest-version: ${{ steps.BUMP_VERSION.outputs.PACKAGE_VERSION }}


### PR DESCRIPTION
Fixes #501 

**Description**

- Fixed: failing CHANGELOG generation action will no longer prevent publish of package.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
skip-ci _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
