### PR TITLE
Prevented secondary click for fixed menu buttons

### DIFF
--- a/lib/components/Editor/CustomExtensions/Image/Menu.jsx
+++ b/lib/components/Editor/CustomExtensions/Image/Menu.jsx
@@ -24,7 +24,7 @@ const Menu = ({ align, updateAttributes, deleteNode }) => {
     >
       {menuOptions.map(({ Icon, optionName, alignPos }) => (
         <Button
-          icon={() => <Icon size={18} />}
+          icon={Icon}
           key={optionName}
           style={alignPos === align ? "secondary" : "text"}
           tooltipProps={{ content: humanize(optionName), position: "top" }}

--- a/lib/components/Editor/CustomExtensions/Mention/index.jsx
+++ b/lib/components/Editor/CustomExtensions/Mention/index.jsx
@@ -16,7 +16,7 @@ const Mentions = ({ editor, mentions }) => {
     <Dropdown
       buttonStyle="text"
       data-cy="neeto-editor-mention-option"
-      icon={() => <Email size={18} />}
+      icon={Email}
       strategy="fixed"
       buttonProps={{
         tooltipProps: { content: "Mention", position: "bottom" },

--- a/lib/components/Editor/CustomExtensions/Variable/index.jsx
+++ b/lib/components/Editor/CustomExtensions/Variable/index.jsx
@@ -21,9 +21,10 @@ const Variables = ({ editor, variables }) => {
 
   return (
     <Dropdown
+      buttonSize="small"
       buttonStyle="secondary"
       data-cy="neeto-editor-variable-option"
-      icon={() => <Braces size={18} />}
+      icon={Braces}
       strategy="fixed"
       buttonProps={{
         tooltipProps: { content: "Variables", position: "bottom" },

--- a/lib/components/Editor/Menu/Bubble/LinkOption.jsx
+++ b/lib/components/Editor/Menu/Bubble/LinkOption.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 
 import { Close } from "neetoicons";
+import { Button } from "neetoui";
 
 import { URL_REGEXP } from "common/constants";
-import { Button } from "neetoui";
 import { isNilOrEmpty } from "utils/common";
 
 const LinkOption = ({ editor, handleClose, handleAnimateInvalidLink }) => {
@@ -56,7 +56,8 @@ const LinkOption = ({ editor, handleClose, handleAnimateInvalidLink }) => {
       />
       <Button
         data-cy="neeto-editor-link-cancel-button"
-        icon={() => <Close size={16} />}
+        icon={Close}
+        size="small"
         style="icon"
         onClick={handleReset}
       />

--- a/lib/components/Editor/Menu/Fixed/EmojiOption.jsx
+++ b/lib/components/Editor/Menu/Fixed/EmojiOption.jsx
@@ -10,7 +10,7 @@ const EmojiOption = ({ editor }) => (
     buttonStyle="text"
     closeOnSelect={false}
     dropdownProps={{ classNames: "neeto-editor-fixed-menu__emoji-dropdown" }}
-    icon={() => <Smiley size={18} />}
+    icon={Smiley}
     position="bottom-start"
     strategy="fixed"
     buttonProps={{

--- a/lib/components/Editor/Menu/Fixed/LinkOption.jsx
+++ b/lib/components/Editor/Menu/Fixed/LinkOption.jsx
@@ -43,7 +43,7 @@ const LinkOption = ({ editor }) => {
       buttonStyle={isActive ? "secondary" : "text"}
       closeOnSelect={false}
       data-cy="neeto-editor-fixed-menu-link-option"
-      icon={() => <Link size={18} />}
+      icon={Link}
       isOpen={isOpen}
       position="bottom"
       buttonProps={{

--- a/lib/components/Editor/Menu/Fixed/utils.jsx
+++ b/lib/components/Editor/Menu/Fixed/utils.jsx
@@ -31,7 +31,7 @@ export const renderOptionButton = ({
     className="neeto-editor-fixed-menu__item"
     data-cy={`neeto-editor-fixed-menu-${optionName}-option`}
     disabled={disabled}
-    icon={() => <Icon size={18} />}
+    icon={Icon}
     key={optionName}
     style={active ? "secondary" : "text"}
     tooltipProps={{ content: humanize(optionName), position: "bottom" }}

--- a/lib/styles/editor/_menu.scss
+++ b/lib/styles/editor/_menu.scss
@@ -15,6 +15,13 @@
     border-radius: var(--neeto-ui-rounded-sm) !important;
   }
 
+  button.neeto-editor-fixed-menu__item {
+    .neeto-ui-btn__icon {
+      height: 18px !important;
+      width: 18px !important;
+    }
+  }
+
   &__wrapper {
     display: flex;
     justify-content: flex-start;
@@ -257,6 +264,13 @@
   .neeto-ui-dropdown__popup {
     display: flex;
     min-width: unset;
+
+    .neeto-ui-btn {
+      .neeto-ui-btn__icon {
+        height: 18px !important;
+        width: 18px !important;
+      }
+    }
   }
 
   &-btn {


### PR DESCRIPTION
Fixes #502 

**Description**

- Fixed: prevented secondary click for menu buttons.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
