### PR TITLE
Limit image file size while copying into editor

### DIFF
--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -139,9 +139,9 @@ const upload = async (file, url) => {
 
     return imageUrl;
   }
-  Toastr.error(`Image size should be less than ${MAX_IMAGE_SIZE / 1024} KB.`);
+  Toastr.error(`Image size should be less than ${MAX_IMAGE_SIZE / 1024} KB`);
 
-  return {};
+  return "";
 };
 
 export default {

--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -139,7 +139,9 @@ const upload = async (file, url) => {
 
     return imageUrl;
   }
-  Toastr.error(`Image size should be less than ${MAX_IMAGE_SIZE / 1024} KB`);
+
+  const imageSizeInMB = MAX_IMAGE_SIZE / (1024 * 1024);
+  Toastr.error(`Image size should be less than ${imageSizeInMB} MB`);
 
   return "";
 };

--- a/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -1,3 +1,4 @@
+import { Toastr } from "@bigbinary/neetoui";
 import { mergeAttributes, Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { Plugin } from "prosemirror-state";
@@ -6,6 +7,8 @@ import { isEmpty } from "ramda";
 import DirectUpload from "utils/DirectUpload";
 
 import ImageComponent from "./ImageComponent";
+
+import { MAX_IMAGE_SIZE } from "../../MediaUploader/constants";
 
 const ImageExtension = Node.create({
   name: "image",
@@ -130,10 +133,15 @@ const ImageExtension = Node.create({
 });
 
 const upload = async (file, url) => {
-  const uploader = new DirectUpload({ file, url });
-  const { blob_url: imageUrl } = await uploader.create();
+  if (file.size <= MAX_IMAGE_SIZE) {
+    const uploader = new DirectUpload({ file, url });
+    const { blob_url: imageUrl } = await uploader.create();
 
-  return imageUrl;
+    return imageUrl;
+  }
+  Toastr.error(`Image size should be less than ${MAX_IMAGE_SIZE / 1024} KB.`);
+
+  return {};
 };
 
 export default {
@@ -167,8 +175,10 @@ export default {
                     const node = schema.nodes.image.create({
                       src: await upload(image, uploadEndpoint),
                     });
-                    const transaction = view.state.tr.insert(pos, node);
-                    view.dispatch(transaction);
+                    if (node.attrs.src) {
+                      const transaction = view.state.tr.insert(pos, node);
+                      view.dispatch(transaction);
+                    }
                   });
                 },
               },

--- a/lib/components/Editor/MediaUploader/constants.js
+++ b/lib/components/Editor/MediaUploader/constants.js
@@ -1,8 +1,9 @@
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
 const MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100 MB
 
 const ALLOWED_IMAGE_TYPES = [".jpg", ".jpeg", ".png", ".gif"];
 const ALLOWED_VIDEO_TYPES = [".mp4", ".mov", ".avi", ".mkv"];
+
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 export const DEFAULT_IMAGE_UPPY_CONFIG = {
   autoProceed: true,


### PR DESCRIPTION
Fixes #418 

Description

- Added file size restriction when pasting an image into the editor.

Reviewers

@AbhayVAshokan _a
