### PR TITLE
Enabled emoji suggestion only right after ":" and a character to enable navigation

### DIFF
--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/EmojiSuggestionMenu.jsx
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/EmojiSuggestionMenu.jsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import classnames from "classnames";
 import { init, SearchIndex } from "emoji-mart";
-import { Kbd, Spinner } from "neetoui";
+import { Spinner } from "neetoui";
+import { isEmpty } from "ramda";
 
 import emojiPickerApi from "apis/emoji_picker";
-import { isNilOrEmpty } from "utils/common";
 
 class EmojiSuggestionMenu extends React.Component {
   state = {
@@ -48,7 +48,7 @@ class EmojiSuggestionMenu extends React.Component {
       return (await SearchIndex.search(this.props.query)).slice(0, 5);
     }
 
-    const defaultEmojis = ["+1", "-1", "smile", "tada", "heart"];
+    const defaultEmojis = [];
     const results = await Promise.all(
       defaultEmojis.map(emoji => SearchIndex.search(emoji))
     );
@@ -74,10 +74,11 @@ class EmojiSuggestionMenu extends React.Component {
   };
 
   onKeyDown = ({ event }) => {
-    if (
-      event.altKey &&
-      (event.key === "ArrowLeft" || event.key === "ArrowDown")
-    ) {
+    if (isEmpty(this.state.emojiSuggestions)) {
+      return false;
+    }
+
+    if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
       this.setState(({ selectedIndex, emojiSuggestions }) => ({
         selectedIndex:
           (selectedIndex + emojiSuggestions.length - 1) %
@@ -87,10 +88,7 @@ class EmojiSuggestionMenu extends React.Component {
       return true;
     }
 
-    if (
-      event.altKey &&
-      (event.key === "ArrowRight" || event.key === "ArrowUp")
-    ) {
+    if (event.key === "ArrowRight" || event.key === "ArrowUp") {
       this.setState(({ selectedIndex, emojiSuggestions }) => ({
         selectedIndex: (selectedIndex + 1) % emojiSuggestions.length,
       }));
@@ -100,16 +98,6 @@ class EmojiSuggestionMenu extends React.Component {
 
     if (event.key === "Enter") {
       this.selectItem(this.state.selectedIndex);
-
-      return true;
-    }
-
-    if (event.key === " ") {
-      if (isNilOrEmpty(this.props.query)) {
-        this.props.editor.chain().focus().insertContent(" ").run();
-      } else {
-        this.setEditorState();
-      }
 
       return true;
     }
@@ -133,6 +121,10 @@ class EmojiSuggestionMenu extends React.Component {
   };
 
   render() {
+    if (isEmpty(this.state.emojiSuggestions)) {
+      return null;
+    }
+
     return (
       <div className="neeto-editor-emoji-suggestion">
         {this.state.isLoading && <Spinner />}
@@ -154,8 +146,6 @@ class EmojiSuggestionMenu extends React.Component {
           ) : (
             <p>No results</p>
           ))}
-        (<Kbd keyName="⌥" />+
-        <Kbd keyName="↔" />)
       </div>
     );
   }

--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/EmojiSuggestionMenu.jsx
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/EmojiSuggestionMenu.jsx
@@ -43,18 +43,10 @@ class EmojiSuggestionMenu extends React.Component {
     }
   };
 
-  searchEmoji = async () => {
-    if (this.props.query) {
-      return (await SearchIndex.search(this.props.query)).slice(0, 5);
-    }
-
-    const defaultEmojis = [];
-    const results = await Promise.all(
-      defaultEmojis.map(emoji => SearchIndex.search(emoji))
-    );
-
-    return results.map(result => result[0]);
-  };
+  searchEmoji = async () =>
+    this.props.query
+      ? (await SearchIndex.search(this.props.query)).slice(0, 5)
+      : [];
 
   searchEmojiAndSetState = async () => {
     const suggestions = await this.searchEmoji();

--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/ExtensionConfig.js
@@ -1,6 +1,7 @@
 import { Node, mergeAttributes } from "@tiptap/core";
 import { ReactRenderer } from "@tiptap/react";
 import Suggestion from "@tiptap/suggestion";
+import { isNil } from "lodash";
 import { PluginKey } from "prosemirror-state";
 import tippy from "tippy.js";
 
@@ -120,39 +121,53 @@ const suggestionConfig = {
 
     return {
       onStart(props) {
-        reactRenderer = new ReactRenderer(EmojiSuggestionMenu, {
-          props,
-          editor: props.editor,
-        });
-
-        popup = tippy("body", {
-          theme: "light",
-          getReferenceClientRect: props.clientRect,
-          appendTo: () => document.body,
-          content: reactRenderer.element,
-          showOnCreate: true,
-          interactive: true,
-          trigger: "manual",
-          placement: "top-start",
-          zIndex: 99999,
-        });
+        if (props.editor.view.input.lastKeyCode === 37) {
+          reactRenderer = null;
+          popup = null;
+        }
       },
 
       onUpdate(props) {
-        reactRenderer.updateProps(props);
+        if (
+          !(
+            props.editor.view.input.lastKeyCode === 39 ||
+            props.editor.view.input.lastKeyCode === 37
+          ) &&
+          props.query.length === 1
+        ) {
+          reactRenderer = new ReactRenderer(EmojiSuggestionMenu, {
+            props,
+            editor: props.editor,
+          });
 
-        popup[0].setProps({
-          getReferenceClientRect: props.clientRect,
-        });
+          popup = tippy("body", {
+            theme: "light",
+            getReferenceClientRect: props.clientRect,
+            appendTo: () => document.body,
+            content: reactRenderer.element,
+            showOnCreate: true,
+            interactive: true,
+            trigger: "manual",
+            placement: "top-start",
+            zIndex: 99999,
+          });
+        }
+        reactRenderer && reactRenderer.updateProps(props);
+
+        !isNil(popup) &&
+          popup[0]?.setProps({
+            getReferenceClientRect: props.clientRect,
+          });
       },
 
       onKeyDown(props) {
-        return reactRenderer.ref?.onKeyDown(props);
+        return reactRenderer?.ref?.onKeyDown(props);
       },
 
       onExit() {
-        popup[0].destroy();
-        reactRenderer.destroy();
+        !isNil(popup) && popup[0]?.destroy();
+        reactRenderer?.destroy();
+        reactRenderer = null;
       },
     };
   },

--- a/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/ExtensionConfig.js
+++ b/lib/components/Editor/CustomExtensions/Emoji/EmojiSuggestion/ExtensionConfig.js
@@ -1,8 +1,8 @@
 import { Node, mergeAttributes } from "@tiptap/core";
 import { ReactRenderer } from "@tiptap/react";
 import Suggestion from "@tiptap/suggestion";
-import { isNil } from "lodash";
 import { PluginKey } from "prosemirror-state";
+import { isNil } from "ramda";
 import tippy from "tippy.js";
 
 import EmojiSuggestionMenu from "./EmojiSuggestionMenu";


### PR DESCRIPTION
Fixes #582 

**Description**

- Fixed: emoji suggestion only right after colon and a character to enable navigation

**Checklist**

- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a