### PR TITLE
Enabled custom configuration for attachments

### DIFF
--- a/lib/components/Attachments/index.jsx
+++ b/lib/components/Attachments/index.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useState, useImperativeHandle } from "react";
 import DropTarget from "@uppy/drop-target";
 import classnames from "classnames";
 import { Button, Toastr } from "neetoui";
-import { isNil } from "ramda";
+import { isEmpty, isNil } from "ramda";
 
 import { DIRECT_UPLOAD_ENDPOINT } from "common/constants";
 import useUppyUploader from "hooks/useUppyUploader";
@@ -152,12 +152,17 @@ const Attachments = (
           />
         )}
         <input
-          accept={config?.allowedFileTypes?.join(",")}
-          disabled={isUploading}
-          multiple={config?.maxNumberOfFiles !== 1}
+          accept={config.allowedFileTypes?.join(",")}
+          multiple={config.maxNumberOfFiles !== 1}
           ref={attachmentInputRef}
           type="file"
           onChange={handleAddFile}
+          onClick={event => {
+            if (!isEmpty(attachments) && config.maxNumberOfFiles === 1) {
+              event.preventDefault();
+              Toastr.warning("Only one attachment is allowed");
+            }
+          }}
         />
       </div>
     </div>

--- a/lib/components/Attachments/index.jsx
+++ b/lib/components/Attachments/index.jsx
@@ -10,7 +10,7 @@ import useUppyUploader from "hooks/useUppyUploader";
 
 import Attachment from "./Attachment";
 import AttachmentProgress from "./AttachmentProgress";
-import { DEFAULT_UPPY_CONFIG } from "./constants";
+import { buildUppyConfig } from "./utils";
 
 const Attachments = (
   {
@@ -21,6 +21,7 @@ const Attachments = (
     isIndependent = true,
     disabled = false,
     dragDropRef = null,
+    config = {},
   },
   ref
 ) => {
@@ -30,7 +31,7 @@ const Attachments = (
 
   const { uppy, isUploading } = useUppyUploader({
     endpoint,
-    uppyConfig: DEFAULT_UPPY_CONFIG,
+    uppyConfig: buildUppyConfig(config),
   });
 
   const handleAddFile = event => {
@@ -151,8 +152,9 @@ const Attachments = (
           />
         )}
         <input
-          multiple
+          accept={config?.allowedFileTypes?.join(",")}
           disabled={isUploading}
+          multiple={config?.maxNumberOfFiles !== 1}
           ref={attachmentInputRef}
           type="file"
           onChange={handleAddFile}

--- a/lib/components/Attachments/utils.js
+++ b/lib/components/Attachments/utils.js
@@ -1,0 +1,6 @@
+import { mergeRight } from "ramda";
+
+import { DEFAULT_UPPY_CONFIG } from "./constants";
+
+export const buildUppyConfig = restrictions =>
+  mergeRight(DEFAULT_UPPY_CONFIG, { restrictions });

--- a/lib/components/Editor/index.jsx
+++ b/lib/components/Editor/index.jsx
@@ -26,34 +26,35 @@ import Attachments from "../Attachments";
 
 const Editor = (
   {
-    initialValue = "",
-    menuType = "fixed",
-    label = "",
-    required = false,
-    autoFocus = false,
-    hideSlashCommands = false,
-    defaults = DEFAULT_EDITOR_OPTIONS,
-    addons = [],
     addonCommands = [],
-    tooltips = {},
+    addons = [],
+    attachments = [],
+    attachmentsConfig = {},
+    autoFocus = false,
     className,
+    config = {},
     contentClassName,
+    defaults = DEFAULT_EDITOR_OPTIONS,
+    editorSecrets = {},
+    error = null,
+    extensions = [],
+    hideSlashCommands = false,
+    initialValue = "",
+    isCharacterCountActive = false,
+    keyboardShortcuts = [],
+    label = "",
+    mentions = [],
+    menuType = "fixed",
+    placeholder,
+    required = false,
+    rows = 6,
+    tooltips = {},
     uploadEndpoint = DIRECT_UPLOAD_ENDPOINT,
+    variables = [],
     onChange = noop,
     onFocus = noop,
     onBlur = noop,
     onSubmit = noop,
-    variables = [],
-    mentions = [],
-    placeholder,
-    extensions = [],
-    editorSecrets = {},
-    rows = 6,
-    isCharacterCountActive = false,
-    keyboardShortcuts = [],
-    error = null,
-    config = {},
-    attachments = [],
     onChangeAttachments = noop,
     ...otherProps
   },
@@ -189,6 +190,7 @@ const Editor = (
             <Attachments
               attachments={attachments}
               className="ne-attachments--integrated"
+              config={attachmentsConfig}
               dragDropRef={dragDropRef}
               isIndependent={false}
               ref={addAttachmentsRef}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "main": "./index.js",
   "module": "./index.js",
   "types": "./types.d.ts",

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -187,4 +187,15 @@ export const EDITOR_PROPS = [
     }
     `,
   ],
+  [
+    "attachmentsConfig",
+    "Accepts an object value. This can be used to configure the attachments addon.",
+    `
+    {
+      maxFileSize: 100 * 1024 * 1024,
+      maxNumberOfFiles: 1,
+      allowedFileTypes: [".pdf"],
+    }
+    `,
+  ],
 ];

--- a/stories/Examples/IndependantMenuComponentDemo.jsx
+++ b/stories/Examples/IndependantMenuComponentDemo.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 
-import { Editor, Menu, Attachments } from "../../lib";
+import { Editor, Menu } from "../../lib";
 
 const IndependantMenuComponent = () => {
   const [editor, setEditor] = useState(null);
@@ -12,13 +12,6 @@ const IndependantMenuComponent = () => {
     <div className="space-y-4">
       <Menu editor={editor} />
       <h2>Other components</h2>
-      <Attachments
-        config={{
-          maxFileSize: 100 * 1024 * 1024,
-          maxNumberOfFiles: 1,
-          allowedFileTypes: [".pdf"],
-        }}
-      />
       <Editor
         autoFocus
         contentClassName="border"

--- a/stories/Examples/IndependantMenuComponentDemo.jsx
+++ b/stories/Examples/IndependantMenuComponentDemo.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 
-import { Editor, Menu } from "../../lib";
+import { Editor, Menu, Attachments } from "../../lib";
 
 const IndependantMenuComponent = () => {
   const [editor, setEditor] = useState(null);
@@ -12,6 +12,13 @@ const IndependantMenuComponent = () => {
     <div className="space-y-4">
       <Menu editor={editor} />
       <h2>Other components</h2>
+      <Attachments
+        config={{
+          maxFileSize: 100 * 1024 * 1024,
+          maxNumberOfFiles: 1,
+          allowedFileTypes: [".pdf"],
+        }}
+      />
       <Editor
         autoFocus
         contentClassName="border"

--- a/stories/Walkthroughs/Attachments/Attachments.stories.mdx
+++ b/stories/Walkthroughs/Attachments/Attachments.stories.mdx
@@ -40,6 +40,14 @@ The Attachments component allows users to upload files by either drag-and-drop o
 <br />
 <br />
 
+#### **Properties of config prop**
+
+> allowedFileTypes: [ ".jpg", ".png", ... ]<br />
+> maxNumberOfFiles: 1 ( for single file or else multiple files can be selected )<br />
+> maxFileSize = 100 \* 1024 \* 1024 ( for 100 MB ).
+
+<br />
+
 ## **Stories**
 <br />
 

--- a/stories/Walkthroughs/Attachments/constants.js
+++ b/stories/Walkthroughs/Attachments/constants.js
@@ -20,6 +20,10 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
     "disabled",
     "If true, the options to download, rename and delete the attachments will be disabled.",
   ],
+  [
+    "config",
+    "Object to customize Attachments component, It has 3 properties: allowedFileTypes, maxNumberOfFiles and maxFileSize.",
+  ],
 ];
 
 export const attachments = [

--- a/types.d.ts
+++ b/types.d.ts
@@ -87,14 +87,21 @@ interface MenuProps {
   className?: string;
 }
 
-type attachment = {
+interface attachment {
   filename?: string;
   signedId?: string;
   url?: string;
   [otherProps: string]: any;
 };
 
+interface attachmentsConfig {
+  maxFileSize?: number,
+  maxNumberOfFiles?: number,
+  allowedFileTypes?: string[],
+}
+
 interface EditorProps {
+  attachmentsConfig?: attachmentsConfig;
   tooltips?: tooltips;
   initialValue?: string;
   menuType?: "fixed" | "bubble" | "headless" | "none";
@@ -131,10 +138,11 @@ interface FormikEditorProps extends EditorProps {
   name: string;
 }
 interface AttachmentsProps {
+  config?: attachmentsConfig;
   endpoint?: string;
   attachments?: Array<attachment>;
   dragDropRef?: React.RefObject<HTMLDivElement>;
-  onChange: (attachments: attachment[]) => void;
+  onChange?: (attachments: attachment[]) => void;
   isIndependent?: boolean;
   disabled?: boolean;
   className?: string;


### PR DESCRIPTION
Fixes #608 
Fixes #609 

**Description**

- Added: custom restriction of type and size for files while uploading.
- Added: support to restrict only selection of single file via file input.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a