### PR TITLE
Removed `react-i18next `from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "ramda": "0.28.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-i18next": "11.16.8",
     "react-router-dom": "5.2.0",
     "react-router-nav-prompt": "0.4.1",
     "react-toastify": "8.0.2",


### PR DESCRIPTION
Fixes #636 

**Description**

- Removed: `react-i18next` from peerDependencies

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a