### PR TITLE
Added support for children prop in every menu type

### DIFF
--- a/lib/components/Editor/Menu/Bubble/Options.jsx
+++ b/lib/components/Editor/Menu/Bubble/Options.jsx
@@ -30,6 +30,7 @@ const Options = ({
   isEmojiPickerActive,
   setIsEmojiPickerActive,
   setIsEmbedModalOpen,
+  children,
 }) => {
   const { t } = useTranslation();
   const { Menu, MenuItem } = Dropdown;
@@ -109,6 +110,7 @@ const Options = ({
         mentions={mentions}
         tooltipContent={tooltips.mention || t("menu.mention")}
       />
+      {children}
     </>
   );
 };

--- a/lib/components/Editor/Menu/Bubble/index.jsx
+++ b/lib/components/Editor/Menu/Bubble/index.jsx
@@ -20,6 +20,7 @@ const Bubble = ({
   isEmojiPickerActive,
   setIsEmojiPickerActive,
   setIsEmbedModalOpen,
+  children,
 }) => {
   const [isInvalidLink, setIsInvalidLink] = useState(false);
   const [isLinkOptionActive, setIsLinkOptionActive] = useState(false);
@@ -70,7 +71,9 @@ const Bubble = ({
           setIsLinkOptionActive={setIsLinkOptionActive}
           setMediaUploader={setMediaUploader}
           tooltips={tooltips}
-        />
+        >
+          {children}
+        </Options>
       </BubbleMenuTipTap>
     </div>
   );

--- a/lib/components/Editor/Menu/Fixed/index.jsx
+++ b/lib/components/Editor/Menu/Fixed/index.jsx
@@ -32,6 +32,7 @@ const Fixed = ({
   isEmojiPickerActive,
   setIsEmojiPickerActive,
   setIsEmbedModalOpen,
+  children,
 }) => {
   const { t } = useTranslation();
 
@@ -100,6 +101,7 @@ const Fixed = ({
           tooltipContent={tooltips.mention || t("menu.mention")}
         />
         {addonCommandOptions.map(renderOptionButton)}
+        {children}
         <div className="neeto-editor-fixed-menu__right-options">
           {rightOptions.map(renderOptionButton)}
         </div>

--- a/stories/Examples/constants.js
+++ b/stories/Examples/constants.js
@@ -59,6 +59,11 @@ export const MENU_PROPS = [
      }`,
   ],
   [
+    "children",
+    "Accepts React nodes to be rendered within the Menu.",
+    `<Button icon={Camera} />`,
+  ],
+  [
     "tooltips",
     "Accepts an object. Use this prop to pass down custom tooltips for the options.",
     `{


### PR DESCRIPTION
Fixes #640 

**Description**

- Added: support for `children` prop in every menu type.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
