### PR TITLE
Added try-catch block to catch errors while adding files to uppy

### DIFF
--- a/lib/components/Attachments/index.jsx
+++ b/lib/components/Attachments/index.jsx
@@ -46,11 +46,17 @@ const Attachments = (
     });
 
     files.forEach(file => {
-      uppy.addFile({
-        name: file.name,
-        type: file.type,
-        data: file,
-      });
+      try {
+        uppy.addFile({
+          name: file.name,
+          type: file.type,
+          data: file,
+        });
+      } catch (error) {
+        if (error.message !== t("error.on-before-file-added-return")) {
+          Toastr.error(t("error.cannot-add-files"));
+        }
+      }
     });
 
     afterAddingFiles();

--- a/lib/translations/en.json
+++ b/lib/translations/en.json
@@ -19,7 +19,9 @@
     "one-attachment-allowed": "Only one attachment is allowed"
   },
   "error": {
-    "invalid-url": "Please enter a valid URL"
+    "invalid-url": "Please enter a valid URL",
+    "cannot-add-files": "Cannot add files",
+    "on-before-file-added-return": "Cannot add the file because onBeforeFileAdded returned false."
   },
   "menu": {
     "attachments": "Attachments",


### PR DESCRIPTION
Fixes #647 

**Description**

- Added: catch block for errors while adding files to uppy

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**
@AbhayVAshokan _a