### PR TITLE
Enabled support for children above EditorContent

### DIFF
--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -34,6 +34,7 @@ const Editor = (
     className,
     contentClassName,
     menuClassName,
+    attachmentsClassName,
     isMenuIndependent = false,
     defaults = DEFAULT_EDITOR_OPTIONS,
     editorSecrets = {},
@@ -197,7 +198,7 @@ const Editor = (
           {isAttachmentsActive && (
             <Attachments
               attachments={attachments}
-              className="ne-attachments--integrated"
+              className={`ne-attachments--integrated ${attachmentsClassName}`}
               config={attachmentsConfig}
               dragDropRef={dragDropRef}
               isIndependent={false}

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -198,11 +198,13 @@ const Editor = (
           {isAttachmentsActive && (
             <Attachments
               attachments={attachments}
-              className={`ne-attachments--integrated ${attachmentsClassName}`}
               config={attachmentsConfig}
               dragDropRef={dragDropRef}
               isIndependent={false}
               ref={addAttachmentsRef}
+              className={classnames("ne-attachments", {
+                [attachmentsClassName]: attachmentsClassName,
+              })}
               onChange={onChangeAttachments}
             />
           )}

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -33,6 +33,8 @@ const Editor = (
     autoFocus = false,
     className,
     contentClassName,
+    menuClassName,
+    isMenuIndependent = false,
     defaults = DEFAULT_EDITOR_OPTIONS,
     editorSecrets = {},
     error = null,
@@ -55,6 +57,7 @@ const Editor = (
     onBlur = noop,
     onSubmit = noop,
     onChangeAttachments = noop,
+    children,
     ...otherProps
   },
   ref
@@ -161,17 +164,19 @@ const Editor = (
           <Menu
             addonCommands={addonCommands}
             addons={addons}
+            className={menuClassName}
             defaults={defaults}
             editor={editor}
             editorSecrets={editorSecrets}
             handleUploadAttachments={handleUploadAttachments}
-            isIndependant={false}
+            isIndependant={isMenuIndependent}
             mentions={mentions}
             menuType={menuType}
             tooltips={tooltips}
             uploadEndpoint={uploadEndpoint}
             variables={variables}
           />
+          {children}
           <EditorContent editor={editor} {...otherProps} />
           {isMediaUploaderActive && (
             <MediaUploader

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import {
   Editor as TiptapEditor,
   Extension,
@@ -75,7 +76,6 @@ interface MenuProps {
   isIndependant?: boolean;
   className?: string;
 }
-
 interface attachment {
   filename?: string;
   signedId?: string;
@@ -91,6 +91,8 @@ interface attachmentsConfig {
 
 interface EditorProps {
   attachmentsConfig?: attachmentsConfig;
+  isMenuIndependent?: boolean;
+  menuClassName?: string;
   tooltips?: tooltips;
   initialValue?: string;
   menuType?: "fixed" | "bubble" | "headless" | "none";
@@ -119,6 +121,7 @@ interface EditorProps {
   error?: string;
   attachments?: Array<attachment>;
   onChangeAttachments?: (attachments: attachment[]) => void;
+  children?: ReactNode;
   [otherProps: string]: any;
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -93,6 +93,7 @@ interface EditorProps {
   attachmentsConfig?: attachmentsConfig;
   isMenuIndependent?: boolean;
   menuClassName?: string;
+  attachmentsClassName?: string;
   tooltips?: tooltips;
   initialValue?: string;
   menuType?: "fixed" | "bubble" | "headless" | "none";


### PR DESCRIPTION
- Fixes #672 

**Description**

- Added: support for children above EditorContent

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@AbhayVAshokan _a
