### PR TITLE
Removed blur command after submitting to keep editor in focus

### DIFF
--- a/src/components/Editor/CustomExtensions/KeyboardShortcuts/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/KeyboardShortcuts/ExtensionConfig.js
@@ -8,7 +8,6 @@ const KeyboardShortcuts = ({ onSubmit, shortcuts }) =>
       return {
         "Mod-Enter": () => {
           onSubmit?.(this.editor.getHTML());
-          this.editor.commands.blur();
 
           return true;
         },


### PR DESCRIPTION
- Fixes #711 

**Description**

- Removed: blur command after submitting to keep editor in focus

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a