### PR TITLE
Fixed issue with displaying text content in codeblocks

### DIFF
--- a/src/components/EditorContent/utils.js
+++ b/src/components/EditorContent/utils.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import { lowlight } from "lowlight";
 import { findBy } from "neetocommons/pure";
+import { isEmpty } from "ramda";
 import { renderToString } from "react-dom/server";
 
 import { CODE_BLOCK_REGEX, VARIABLE_SPAN_REGEX } from "./constants";
@@ -20,9 +21,13 @@ const buildReactElementFromAST = element => {
 
 export const highlightCode = content =>
   content.replace(CODE_BLOCK_REGEX, (_, code) => {
-    const highlightedAST = lowlight.highlightAuto(
+    let highlightedAST = lowlight.highlightAuto(
       code.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&")
     );
+
+    if (isEmpty(highlightedAST.children)) {
+      highlightedAST = lowlight.highlight("javascript", code);
+    }
 
     const highlightedNode = highlightedAST.children.map(
       buildReactElementFromAST


### PR DESCRIPTION
- Fixes #724 

**Description**

- Fixed: issue with displaying text content in codeblocks by giving a default fallback to javascript if no matches found in `highlightAuto` function

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a