### PR TITLE
Removed terser plugin and generated map files for output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ yarn-error.log*
 /editor-content.js
 /index.js
 /index.cjs.js
-/index.js
 /index.*.map
 /formik.js
 storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # production
 /build
 /dist/editor-output.js
+/dist/editor-output.js.map
+/dist/codeBlockHighlight.js.map
 
 # misc
 .DS_Store
@@ -26,5 +28,7 @@ yarn-error.log*
 /editor-content.js
 /index.js
 /index.cjs.js
+/index.js
+/index.*.map
 /formik.js
 storybook-static

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-replace": "4.0.0",
-    "@rollup/plugin-terser": "^0.4.0",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/addon-docs": "6.5.16",
     "@storybook/addon-essentials": "6.5.16",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,7 +50,7 @@ export default [
     output: formats.map(format => ({
       file: format === "esm" ? "./index.js" : "./index.cjs.js",
       format,
-      sourcemap: false,
+      sourcemap: true,
       name: "neetoEditor",
       assetFileNames: "[name][extname]",
     })),
@@ -61,6 +61,7 @@ export default [
     output: {
       dir: `${__dirname}/dist`,
       format: "esm",
+      sourcemap: true,
       assetFileNames: "[name][extname]",
     },
     plugins: [
@@ -76,7 +77,7 @@ export default [
     output: {
       dir: `${__dirname}/dist`,
       format: "cjs",
-      sourcemap: false,
+      sourcemap: true,
       assetFileNames: "[name][extname]",
     },
     plugins,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,15 +2254,6 @@
     "@rollup/pluginutils" "^3.1.0"
     magic-string "^0.25.7"
 
-"@rollup/plugin-terser@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz#4c76249ad337f3eb04ab409332f23717af2c1fbf"
-  integrity sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==
-  dependencies:
-    serialize-javascript "^6.0.0"
-    smob "^0.0.6"
-    terser "^5.15.1"
-
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -13615,11 +13606,6 @@ slice-ansi@^5.0.0:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
 
-smob@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/smob/-/smob-0.0.6.tgz#09b268fea916158a2781c152044c6155adbb8aa1"
-  integrity sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -14290,16 +14276,6 @@ terser@^5.10.0, terser@^5.14.1, terser@^5.3.4:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.0.tgz#e16967894eeba6e1091509ec83f0c60e179f2425"
   integrity sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.2"
-    acorn "^8.5.0"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
-terser@^5.15.1:
-  version "5.16.6"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.6.tgz#f6c7a14a378ee0630fbe3ac8d1f41b4681109533"
-  integrity sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
- Fixes #727 

**Description**
- Removed `@rollup/terser-plugin`.
- Set `sourcemap: true` for output files.

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have updated the types definition of modified exports.~~
- ~~[ ] I have verified the functionality in some of the neeto web-apps.~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).


<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->

patch _t