### PR TITLE
Fixed link getting applied on complete line

### DIFF
--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -49,7 +49,7 @@ const useCustomExtensions = ({
     Highlight,
     CodeBlock,
     FigCaption,
-    Link,
+    Link.configure({ autolink: false }),
     EmojiSuggestion,
     EmojiPicker,
     CustomCommands,


### PR DESCRIPTION
- Fixes #746 

**Description**

- Fixed: link getting applied on complete line

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
