### PR TITLE
Added a custom extension to retain text highlighting

### DIFF
--- a/src/components/Editor/CustomExtensions/BackgroundColor/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/BackgroundColor/ExtensionConfig.js
@@ -2,7 +2,7 @@ import { Extension } from "@tiptap/core";
 import "@tiptap/extension-text-style";
 
 export default Extension.create({
-  name: "BackgroundColor",
+  name: "HighlightInternal",
 
   addOptions() {
     return {
@@ -36,11 +36,11 @@ export default Extension.create({
 
   addCommands() {
     return {
-      setBackgroundColor:
+      setHighlightInternal:
         color =>
         ({ chain }) =>
           chain().setMark("textStyle", { backgroundColor: color }).run(),
-      unsetBackgroundColor:
+      unsetHighlightInternal:
         () =>
         ({ chain }) =>
           chain().setMark("textStyle", { backgroundColor: null }).run(),

--- a/src/components/Editor/CustomExtensions/BackgroundColor/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/BackgroundColor/ExtensionConfig.js
@@ -1,0 +1,49 @@
+import { Extension } from "@tiptap/core";
+import "@tiptap/extension-text-style";
+
+export default Extension.create({
+  name: "BackgroundColor",
+
+  addOptions() {
+    return {
+      types: ["textStyle"],
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          backgroundColor: {
+            default: null,
+            parseHTML: element =>
+              element.style.backgroundColor.replace(/['"]+/g, ""),
+            renderHTML: attributes => {
+              if (!attributes.backgroundColor) {
+                return {};
+              }
+
+              return {
+                style: `background-color: ${attributes.backgroundColor}`,
+              };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setBackgroundColor:
+        color =>
+        ({ chain }) =>
+          chain().setMark("textStyle", { backgroundColor: color }).run(),
+      unsetBackgroundColor:
+        () =>
+        ({ chain }) =>
+          chain().setMark("textStyle", { backgroundColor: null }).run(),
+    };
+  },
+});

--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -15,7 +15,7 @@ import { isEmpty } from "ramda";
 
 import { EDITOR_OPTIONS } from "common/constants";
 
-import BackgroundColor from "../BackgroundColor/ExtensionConfig";
+import HighlightInternal from "../BackgroundColor/ExtensionConfig";
 import CodeBlock from "../CodeBlock/ExtensionConfig";
 import CustomCommands from "../CustomCommands/ExtensionConfig";
 import Embeds from "../Embeds/ExtensionConfig";
@@ -56,13 +56,14 @@ const useCustomExtensions = ({
     EmojiSuggestion,
     EmojiPicker,
     FigCaption,
-    BackgroundColor,
+    HighlightInternal,
     Focus.configure({ mode: "shallowest" }),
     Highlight,
     ImageExtension.configure({ uploadEndpoint }),
     Link.configure({ autolink: false }),
     Placeholder.configure({ placeholder }),
     StarterKit.configure({ document: false, codeBlock: false, code: false }),
+    TextStyle,
     Underline,
     VideoExtension,
     KeyboardShortcuts.configure({
@@ -84,7 +85,7 @@ const useCustomExtensions = ({
   }
 
   if (options.includes(EDITOR_OPTIONS.TEXT_COLOR)) {
-    customExtensions.push(Color, TextStyle);
+    customExtensions.push(Color);
   }
 
   if (isSlashCommandsActive) {

--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -1,6 +1,6 @@
 import CharacterCount from "@tiptap/extension-character-count";
 import Code from "@tiptap/extension-code";
-import { Color } from "@tiptap/extension-color";
+import Color from "@tiptap/extension-color";
 import Document from "@tiptap/extension-document";
 import Focus from "@tiptap/extension-focus";
 import Highlight from "@tiptap/extension-highlight";
@@ -15,6 +15,7 @@ import { isEmpty } from "ramda";
 
 import { EDITOR_OPTIONS } from "common/constants";
 
+import BackgroundColor from "../BackgroundColor/ExtensionConfig";
 import CodeBlock from "../CodeBlock/ExtensionConfig";
 import CustomCommands from "../CustomCommands/ExtensionConfig";
 import Embeds from "../Embeds/ExtensionConfig";
@@ -55,6 +56,7 @@ const useCustomExtensions = ({
     EmojiSuggestion,
     EmojiPicker,
     FigCaption,
+    BackgroundColor,
     Focus.configure({ mode: "shallowest" }),
     Highlight,
     ImageExtension.configure({ uploadEndpoint }),

--- a/src/components/Editor/Menu/Fixed/LinkOption.jsx
+++ b/src/components/Editor/Menu/Fixed/LinkOption.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Link } from "neetoicons";
 import { Button, Dropdown, Input } from "neetoui";
@@ -50,6 +50,16 @@ const LinkOption = ({ editor, tooltipContent }) => {
     setUrlString("");
     handleClose();
   };
+
+  useEffect(() => {
+    editor.commands.setBackgroundColor("#ACCEF7");
+
+    if (!isOpen) {
+      editor.commands.unsetBackgroundColor();
+      editor.commands.removeEmptyTextStyle();
+      editor.commands.focus();
+    }
+  }, [isOpen]);
 
   return (
     <Dropdown

--- a/src/components/Editor/Menu/Fixed/LinkOption.jsx
+++ b/src/components/Editor/Menu/Fixed/LinkOption.jsx
@@ -52,10 +52,10 @@ const LinkOption = ({ editor, tooltipContent }) => {
   };
 
   useEffect(() => {
-    editor.commands.setBackgroundColor("#ACCEF7");
+    editor.commands.setHighlightInternal("#ACCEF7");
 
     if (!isOpen) {
-      editor.commands.unsetBackgroundColor();
+      editor.commands.unsetHighlightInternal();
       editor.commands.removeEmptyTextStyle();
       editor.commands.focus();
     }

--- a/src/components/Editor/Menu/Fixed/TextColorOption.jsx
+++ b/src/components/Editor/Menu/Fixed/TextColorOption.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { useFuncDebounce, useOnClickOutside } from "neetocommons/react-utils";
 import { Customize } from "neetoicons";
@@ -31,10 +31,22 @@ const TextColorOption = ({ editor, tooltipContent }) => {
   };
 
   useOnClickOutside(dropdownWrapperRef, event => {
-    isOpen && event.preventDefault();
-    editor.commands.focus();
-    setIsOpen(false);
+    if (isOpen) {
+      event.preventDefault();
+      editor.commands.focus();
+      setIsOpen(false);
+    }
   });
+
+  useEffect(() => {
+    editor.commands.setBackgroundColor("#ACCEF7");
+
+    if (!isOpen) {
+      editor.commands.unsetBackgroundColor();
+      editor.commands.removeEmptyTextStyle();
+      editor.commands.focus();
+    }
+  }, [isOpen]);
 
   return (
     <div ref={dropdownWrapperRef}>

--- a/src/components/Editor/Menu/Fixed/TextColorOption.jsx
+++ b/src/components/Editor/Menu/Fixed/TextColorOption.jsx
@@ -39,10 +39,10 @@ const TextColorOption = ({ editor, tooltipContent }) => {
   });
 
   useEffect(() => {
-    editor.commands.setBackgroundColor("#ACCEF7");
+    editor.commands.setHighlightInternal("#ACCEF7");
 
     if (!isOpen) {
-      editor.commands.unsetBackgroundColor();
+      editor.commands.unsetHighlightInternal();
       editor.commands.removeEmptyTextStyle();
       editor.commands.focus();
     }


### PR DESCRIPTION
- Fixes #745 

**Description**

- Added: `BackgroundColor` custom extension to retain text highlighting

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
~~- [x] I have verified the functionality in some of the neeto web-apps.~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
