### PR TITLE
Removed deprecated order_by param from unsplash api

### DIFF
--- a/src/apis/unsplash.js
+++ b/src/apis/unsplash.js
@@ -10,7 +10,6 @@ export const searchUnsplashImages = ({ pageNo, query, apiKey }) =>
     params: {
       page: pageNo,
       per_page: 30,
-      order_by: "popular",
       query,
     },
   });


### PR DESCRIPTION
- Fixes #764 

**Description**

- Removed: order_by from unsplash request params

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a