### PR TITLE
Fixed the sentence casing of the 'Add attachment' button

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -15,7 +15,7 @@
   },
   "attachments": {
     "actionsBlocked": "You are not permitted to update or delete attachments",
-    "add": "Add Attachment",
+    "add": "Add attachment",
     "deleteConfirmation": "Are you sure you want to remove {{entity}}?",
     "deleteTitle": "Remove Attachment?",
     "maxNumberOfFiles": "You can only attach {{entity}} files",


### PR DESCRIPTION
- Fixes #769 

**Description**

- Updated "Add Attachment" to "Add attachment" for Attachments.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] ~I have verified the functionality in some of the neeto web-apps.~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
