### PR TITLE
Updated highlightCode function in EditorContent for parsing code-block

### DIFF
--- a/src/components/EditorContent/utils.js
+++ b/src/components/EditorContent/utils.js
@@ -1,5 +1,6 @@
 import React from "react";
 
+import hljs from "highlight.js/lib/common";
 import { lowlight } from "lowlight";
 import { findBy } from "neetocommons/pure";
 import { isEmpty } from "ramda";
@@ -21,9 +22,9 @@ const buildReactElementFromAST = element => {
 
 export const highlightCode = content =>
   content.replace(CODE_BLOCK_REGEX, (_, code) => {
-    let highlightedAST = lowlight.highlightAuto(
+    let highlightedAST = hljs.highlightAuto(
       code.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&")
-    );
+    )._emitter.root;
 
     if (isEmpty(highlightedAST.children)) {
       highlightedAST = lowlight.highlight("javascript", code);


### PR DESCRIPTION
- Fixes #772 

**Description**

- Changed: `highlightCode` function in `EditorContent` to parse codeblocks

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a