### PR TITLE
Initialized hljs before parsing content

### DIFF
--- a/src/components/EditorContent/utils.js
+++ b/src/components/EditorContent/utils.js
@@ -20,8 +20,10 @@ const buildReactElementFromAST = element => {
   return element.value;
 };
 
-export const highlightCode = content =>
-  content.replace(CODE_BLOCK_REGEX, (_, code) => {
+export const highlightCode = content => {
+  lowlight.highlightAuto("");
+
+  return content.replace(CODE_BLOCK_REGEX, (_, code) => {
     let highlightedAST = hljs.highlightAuto(
       code.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&")
     )._emitter.root;
@@ -36,7 +38,7 @@ export const highlightCode = content =>
 
     return `<pre><code>${renderToString(highlightedNode)}</code></pre>`;
   });
-
+};
 export const substituteVariables = (highlightedContent, variables) =>
   highlightedContent.replace(VARIABLE_SPAN_REGEX, (matchedSpan, dataLabel) => {
     const dataLabelSplitted = dataLabel.split(".");


### PR DESCRIPTION
- Fixes #775

**Description**

- Fixed: EditorContent not parsing codeblocks using correct language preference

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a