### PR TITLE
Added ability to disable the success toaster while updating and deleting attachments

### DIFF
--- a/src/apis/direct_uploads.js
+++ b/src/apis/direct_uploads.js
@@ -15,13 +15,17 @@ const create = (url, file, config) =>
     showToastr: false,
   });
 
-const update = ({ url, signedId, payload }) =>
+const update = ({ url, signedId, payload, showToastr }) =>
   axios.patch(`${url}/${signedId}/`, payload, {
     transformRequestCase: false,
     transformResponseCase: false,
+    showToastr,
   });
 
-const destroy = (url, signedId) => axios.delete(`${url}/${signedId}`);
+const destroy = (url, signedId, showToastr) =>
+  axios.delete(`${url}/${signedId}`, {
+    showToastr,
+  });
 
 const directUploadsApi = { generate, create, update, destroy };
 

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import saveAs from "file-saver";
 import { removeBy } from "neetocommons/pure";
+import { withEventTargetValue } from "neetocommons/utils";
 import { MenuVertical, Close } from "neetoicons";
 import {
   Dropdown,
@@ -29,6 +30,7 @@ const Attachment = ({
   endpoint,
   onChange,
   setSelectedAttachment,
+  showToastr,
 }) => {
   const { t } = useTranslation();
 
@@ -50,7 +52,12 @@ const Attachment = ({
 
       const {
         blob: { filename },
-      } = await directUploadsApi.update({ url: endpoint, signedId, payload });
+      } = await directUploadsApi.update({
+        url: endpoint,
+        signedId,
+        payload,
+        showToastr,
+      });
 
       onChange(
         attachments.map(attachment =>
@@ -71,7 +78,7 @@ const Attachment = ({
     setIsDeleting(true);
     try {
       const { signedId } = attachment;
-      await directUploadsApi.destroy(endpoint, signedId);
+      await directUploadsApi.destroy(endpoint, signedId, showToastr);
       onChange(removeBy({ signedId }, attachments));
     } catch (error) {
       Toastr.error(error);
@@ -122,7 +129,7 @@ const Attachment = ({
                 error={isEmpty(newFilename) ? t("attachments.nameEmpty") : ""}
                 size="small"
                 value={newFilename}
-                onChange={e => setNewFilename(e.target.value)}
+                onChange={withEventTargetValue(setNewFilename)}
                 onKeyDown={event =>
                   handleKeyDown({
                     event,

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -25,6 +25,7 @@ const Attachments = (
     disabled = false,
     dragDropRef = null,
     config = {},
+    showToastr = true,
   },
   ref
 ) => {
@@ -161,6 +162,7 @@ const Attachments = (
             endpoint={endpoint}
             key={attachment.signedId}
             setSelectedAttachment={setSelectedAttachment}
+            showToastr={showToastr}
             onChange={onChange}
           />
         ))}

--- a/src/components/Editor/CustomExtensions/Embeds/index.jsx
+++ b/src/components/Editor/CustomExtensions/Embeds/index.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from "react";
 
+import { withEventTargetValue } from "neetocommons/utils";
 import { Button, Input, Modal, Typography } from "neetoui";
 import { isEmpty } from "ramda";
 import { useTranslation } from "react-i18next";
@@ -36,13 +37,13 @@ const EmbedOption = ({ isEmbedModalOpen, setIsEmbedModalOpen, editor }) => {
     }
   };
 
-  const handleChange = e => {
-    if (validateUrl(e.target.value)) {
+  const handleChange = url => {
+    if (validateUrl(url)) {
       setError(false);
-      setEmbedUrl(e.target.value);
+      setEmbedUrl(url);
     } else {
       setError(true);
-      setEmbedUrl(e.target.value);
+      setEmbedUrl(url);
     }
   };
 
@@ -78,7 +79,7 @@ const EmbedOption = ({ isEmbedModalOpen, setIsEmbedModalOpen, editor }) => {
           size="medium"
           type="text"
           value={embedUrl}
-          onChange={handleChange}
+          onChange={withEventTargetValue(handleChange)}
           onKeyDown={handleKeyDown}
         />
       </Modal.Body>

--- a/src/components/Editor/Menu/Bubble/TableOption.jsx
+++ b/src/components/Editor/Menu/Bubble/TableOption.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 
+import { withEventTargetValue } from "neetocommons/utils";
 import { Check, Close } from "neetoicons";
 import { Button, Dropdown } from "neetoui";
 import { useTranslation } from "react-i18next";
@@ -37,7 +38,7 @@ const TableOption = ({ editor, handleClose }) => {
             placeholder={t("placeholders.rows")}
             type="number"
             value={rows}
-            onChange={e => setRows(e.target.value)}
+            onChange={withEventTargetValue(setRows)}
           />
           <input
             data-cy="neeto-editor-bubble-menu-table-option-input"
@@ -45,7 +46,7 @@ const TableOption = ({ editor, handleClose }) => {
             placeholder={t("placeholders.columns")}
             type="number"
             value={columns}
-            onChange={e => setColumns(e.target.value)}
+            onChange={withEventTargetValue(setColumns)}
           />
           <div className="neeto-editor-bubble-menu__table__buttons">
             <Button

--- a/src/components/Editor/Menu/Fixed/TableOption.jsx
+++ b/src/components/Editor/Menu/Fixed/TableOption.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 
+import { withEventTargetValue } from "neetocommons/utils";
 import { NeetoChangelog } from "neetoicons";
 import { Button, Dropdown, Input } from "neetoui";
 import { useTranslation } from "react-i18next";
@@ -52,7 +53,7 @@ const TableOption = ({ editor, tooltipContent }) => {
           size="small"
           type="number"
           value={rows}
-          onChange={e => setRows(e.target.value)}
+          onChange={withEventTargetValue(setRows)}
         />
         <Input
           data-cy="neeto-editor-fixed-menu-table-option-input"
@@ -61,7 +62,7 @@ const TableOption = ({ editor, tooltipContent }) => {
           size="small"
           type="number"
           value={columns}
-          onChange={e => setColumns(e.target.value)}
+          onChange={withEventTargetValue(setColumns)}
         />
         <Button
           data-cy="neeto-editor-fixed-menu-table-option-create-button"

--- a/src/components/Editor/Menu/Fixed/TextColorOption.jsx
+++ b/src/components/Editor/Menu/Fixed/TextColorOption.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import { useFuncDebounce, useOnClickOutside } from "neetocommons/react-utils";
+import { withEventTargetValue } from "neetocommons/utils";
 import { Customize } from "neetoicons";
 import { Button, Dropdown, Input } from "neetoui";
 import { not } from "ramda";
@@ -74,7 +75,7 @@ const TextColorOption = ({ editor, tooltipContent }) => {
             placeholder={t("placeholders.pickColor")}
             size="small"
             value={color}
-            onChange={e => setColor(e.target.value)}
+            onChange={withEventTargetValue(setColor)}
           />
           <Button
             className="neeto-editor-text-color-option__options-group__reset-button"

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -60,6 +60,7 @@ const Editor = (
     onSubmit = noop,
     onChangeAttachments = noop,
     children,
+    showAttachmentsToastr = true,
     ...otherProps
   },
   ref
@@ -208,6 +209,7 @@ const Editor = (
               dragDropRef={dragDropRef}
               isIndependent={false}
               ref={addAttachmentsRef}
+              showToastr={showAttachmentsToastr}
               className={classnames("ne-attachments--integrated", {
                 [attachmentsClassName]: attachmentsClassName,
               })}

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -67,7 +67,7 @@ export const EDITOR_PROPS = [
   [
     "addons",
     "Accepts an array of strings, each corresponding to the name of an addon.",
-    `["highlight", "emoji", "code-block", "block-quote", "image-upload", "video-upload", "divider", "video-embed", "paste-unformatted"]`,
+    `["highlight", "emoji", "code-block", "block-quote", "image-upload", "video-upload", "divider", "video-embed", "paste-unformatted","attachments"]`,
   ],
   [
     "addonCommands",
@@ -103,7 +103,7 @@ export const EDITOR_PROPS = [
   ],
   [
     "onChange",
-    "Accepts a function. This function will be invoked whenever the editor content changes, with new the content as argument.",
+    "Accepts a function. This function will be invoked whenever the editor content changes, with the new content as argument.",
     `(newContent) => {}`,
   ],
   [
@@ -179,6 +179,15 @@ export const EDITOR_PROPS = [
     "This field is required",
   ],
   [
+    "attachments",
+    "Accepts an array of attachment objects. This array will be used to display the attachments in the editor.",
+  ],
+  [
+    "onChangeAttachments",
+    "Accepts a function. This function will be invoked whenever the attachments are changed, with the new attachments as argument.",
+    `(newContent) => {}`,
+  ],
+  [
     "attachmentsConfig",
     "Accepts an object value. This can be used to configure the attachments addon.",
     `
@@ -188,5 +197,9 @@ export const EDITOR_PROPS = [
       allowedFileTypes: [".pdf"],
     }
     `,
+  ],
+  [
+    "showAttachmentsToastr",
+    "Accepts a boolean value. If provided, it will show a toast message when the attachments are updated/deleted.",
   ],
 ];

--- a/stories/Walkthroughs/Attachments/Attachments.stories.mdx
+++ b/stories/Walkthroughs/Attachments/Attachments.stories.mdx
@@ -36,7 +36,7 @@ handling the file upload process.
 
 #### **Props**
 
-<Table columns={EDITOR_ADDONS_TABLE_COLUMNS} rows={EDITOR_ADDONS_TABLE_ROWS} />
+<Table columns={ATTACHMENTS_TABLE_COLUMNS} rows={ATTACHMENTS_TABLE_ROWS} />
 <br />
 <br />
 

--- a/stories/Walkthroughs/Attachments/constants.js
+++ b/stories/Walkthroughs/Attachments/constants.js
@@ -1,6 +1,8 @@
-export const EDITOR_ADDONS_TABLE_COLUMNS = ["Prop", "Description"];
+import { noop } from "neetocommons/pure";
 
-export const EDITOR_ADDONS_TABLE_ROWS = [
+export const ATTACHMENTS_TABLE_COLUMNS = ["Prop", "Description"];
+
+export const ATTACHMENTS_TABLE_ROWS = [
   ["attachments", "An array of the metadata of all the attachments."],
   [
     "onChange",
@@ -24,6 +26,10 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
     "config",
     "Object to customize Attachments component, It has 3 properties: allowedFileTypes, maxNumberOfFiles and maxFileSize.",
   ],
+  [
+    "showToastr",
+    "Boolean to show/hide toastr when an attachment is deleted/renamed, default value is true.",
+  ],
 ];
 
 export const attachments = [
@@ -39,4 +45,4 @@ export const attachments = [
   },
 ];
 
-export const setAttachments = () => {};
+export const setAttachments = noop;

--- a/types.d.ts
+++ b/types.d.ts
@@ -122,6 +122,7 @@ interface EditorProps {
   error?: string;
   attachments?: Array<attachment>;
   onChangeAttachments?: (attachments: attachment[]) => void;
+  showAttachmentsToastr?: boolean;
   children?: ReactNode;
   [otherProps: string]: any;
 }
@@ -138,6 +139,7 @@ interface AttachmentsProps {
   isIndependent?: boolean;
   disabled?: boolean;
   className?: string;
+  showToastr?: boolean;
 }
 
 export function Editor(props: EditorProps): JSX.Element;


### PR DESCRIPTION
- Fixes #778 

**Description**

- Added: `showAttachmentsToastr` prop for editor
- Added: `showToatr` prop for attachments

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a