### PR TITLE
Updated the Attachment rename option to not trigger onSubmit function when pressing "Enter" key inside input

### DIFF
--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -107,6 +107,7 @@ const Attachment = ({
     const handler = handlers[key];
 
     if (event.key === "Enter" && handler && !isEmpty(newFilename)) {
+      event.stopPropagation();
       event.preventDefault();
       handler();
     }


### PR DESCRIPTION
- Fixes #790 

**Description**

- Fixed: Rename attachment option triggering form submit

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan
