### PR TITLE
Disabled slash-commands in image and codeBlock nodes

### DIFF
--- a/src/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -62,6 +62,13 @@ export default {
 
               return {
                 onStart: props => {
+                  if (
+                    props.editor.isActive("image") ||
+                    props.editor.isActive("codeBlock")
+                  ) {
+                    return;
+                  }
+
                   reactRenderer = new ReactRenderer(CommandsList, {
                     props,
                     editor: props.editor,


### PR DESCRIPTION
- Fixes #718 

**Description**

- Fixed: issues with slash commands, disables slash-commands in "image" and "codeBlock" nodes

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a