### PR TITLE
Passed the 'name' attribute to the 'div' element in 'FormikEditor'

### DIFF
--- a/dist/codeBlockHighlight.js
+++ b/dist/codeBlockHighlight.js
@@ -15070,13 +15070,13 @@ hljs.HighlightJS = hljs;
 hljs.default = hljs;
 var common = hljs;
 
-function cov_1ah9bessw2() {
-  var path = "/home/runner/work/neeto-editor/neeto-editor/src/components/EditorContent/codeBlockHighlight.js";
-  var hash = "7c78a5dd785a278e46ddf58d789e4d5c33935fcb";
+function cov_12ty4ueljx() {
+  var path = "/Users/abhayvashokan/Documents/Work/Projects/neeto-editor/src/components/EditorContent/codeBlockHighlight.js";
+  var hash = "00bf5abc8efd2fb0e9a7856031ef5c7878f112ed";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/home/runner/work/neeto-editor/neeto-editor/src/components/EditorContent/codeBlockHighlight.js",
+    path: "/Users/abhayvashokan/Documents/Work/Projects/neeto-editor/src/components/EditorContent/codeBlockHighlight.js",
     statementMap: {
       "0": {
         start: {
@@ -15171,7 +15171,7 @@ function cov_1ah9bessw2() {
     },
     b: {},
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "7c78a5dd785a278e46ddf58d789e4d5c33935fcb"
+    hash: "00bf5abc8efd2fb0e9a7856031ef5c7878f112ed"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -15180,20 +15180,20 @@ function cov_1ah9bessw2() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_1ah9bessw2 = function () {
+    cov_12ty4ueljx = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_1ah9bessw2();
-cov_1ah9bessw2().s[0]++;
+cov_12ty4ueljx();
+cov_12ty4ueljx().s[0]++;
 document.addEventListener("DOMContentLoaded", function () {
-  cov_1ah9bessw2().f[0]++;
-  cov_1ah9bessw2().s[1]++;
+  cov_12ty4ueljx().f[0]++;
+  cov_12ty4ueljx().s[1]++;
   document.querySelectorAll("pre code").forEach(function (element) {
-    cov_1ah9bessw2().f[1]++;
-    cov_1ah9bessw2().s[2]++;
+    cov_12ty4ueljx().f[1]++;
+    cov_12ty4ueljx().s[2]++;
     return common.highlightElement(element);
   });
 });

--- a/src/components/Editor/FormikEditor.jsx
+++ b/src/components/Editor/FormikEditor.jsx
@@ -10,6 +10,7 @@ const FormikEditor = ({ name, ...otherProps }, ref) => (
       <Editor
         error={meta.touched ? meta.error : ""}
         initialValue={field.value}
+        name={name}
         ref={ref}
         onBlur={() => form.setFieldTouched(name, true)}
         onChange={value => form.setFieldValue(name, value)}


### PR DESCRIPTION
- Fixes #816 

**Description**
- In `FormikEditor`, the `name` attribute will be passed to the `div` rendering the `Editor` component.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
cc: @soorajjtk: This will be released via compliance.

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
