### PR TITLE
Made ammendments to code-block ui and language selection

### DIFF
--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { NodeViewWrapper, NodeViewContent } from "@tiptap/react";
 import { copyToClipboard } from "neetocommons/utils";
@@ -28,6 +28,10 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
     setKeyword("");
   };
 
+  useEffect(() => {
+    updateAttributes({ language: "plaintext" });
+  }, []);
+
   return (
     <NodeViewWrapper data-cy="neeto-editor-code-block">
       <pre>
@@ -38,7 +42,6 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
             closeOnOutsideClick={false}
             icon={Down}
             label={node.attrs?.language || t("common.auto")}
-            strategy="fixed"
           >
             <Input
               autoFocus

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -4,7 +4,7 @@ import { NodeViewWrapper, NodeViewContent } from "@tiptap/react";
 import { copyToClipboard } from "neetocommons/utils";
 import { Copy, Down } from "neetoicons";
 import { Button, Dropdown, Input } from "neetoui";
-import { equals, isNil } from "ramda";
+import { isNil } from "ramda";
 import { useTranslation } from "react-i18next";
 
 import { SORTED_LANGUAGE_LIST } from "./constants";
@@ -24,7 +24,7 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
     copyToClipboard(node?.content?.content[0]?.text);
 
   const handleLanguageSelect = language => {
-    updateAttributes({ language: equals(language, "auto") ? null : language });
+    updateAttributes({ language });
     setKeyword("");
   };
 
@@ -39,7 +39,6 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
           <Dropdown
             buttonSize="small"
             buttonStyle="secondary"
-            closeOnOutsideClick={false}
             icon={Down}
             label={node.attrs?.language || t("common.auto")}
             strategy="fixed"

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -42,6 +42,7 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
             closeOnOutsideClick={false}
             icon={Down}
             label={node.attrs?.language || t("common.auto")}
+            strategy="fixed"
           >
             <Input
               autoFocus

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -4,7 +4,7 @@ import { NodeViewWrapper, NodeViewContent } from "@tiptap/react";
 import { copyToClipboard } from "neetocommons/utils";
 import { Copy, Down } from "neetoicons";
 import { Button, Dropdown, Input } from "neetoui";
-import { equals } from "ramda";
+import { equals, isNil } from "ramda";
 import { useTranslation } from "react-i18next";
 
 import { SORTED_LANGUAGE_LIST } from "./constants";
@@ -29,7 +29,7 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
   };
 
   useEffect(() => {
-    updateAttributes({ language: "plaintext" });
+    isNil(node.attrs?.language) && updateAttributes({ language: "plaintext" });
   }, []);
 
   return (

--- a/src/components/Editor/CustomExtensions/CodeBlock/constants.js
+++ b/src/components/Editor/CustomExtensions/CodeBlock/constants.js
@@ -1,5 +1,3 @@
 import { lowlight } from "lowlight";
 
-export const SORTED_LANGUAGE_LIST = ["auto"].concat(
-  lowlight.listLanguages().sort()
-);
+export const SORTED_LANGUAGE_LIST = lowlight.listLanguages().sort();

--- a/src/components/EditorContent/utils.js
+++ b/src/components/EditorContent/utils.js
@@ -8,6 +8,9 @@ import { renderToString } from "react-dom/server";
 
 import { CODE_BLOCK_REGEX, VARIABLE_SPAN_REGEX } from "./constants";
 
+const transformCode = code =>
+  code.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&");
+
 const buildReactElementFromAST = element => {
   if (element.tagName) {
     const children = element.children
@@ -26,14 +29,11 @@ export const highlightCode = content => {
 
   return content.replace(CODE_BLOCK_REGEX, (_, language, code) => {
     if (language) {
-      highlightedAST = lowlight.highlight(language, code);
+      highlightedAST = lowlight.highlight(language, transformCode(code));
     } else {
-      highlightedAST = hljs.highlightAuto(
-        code.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&")
-      )._emitter.root;
-
+      highlightedAST = hljs.highlightAuto(transformCode(code))._emitter.root;
       if (isEmpty(highlightedAST.children)) {
-        highlightedAST = lowlight.highlight("javascript", code);
+        highlightedAST = lowlight.highlight("javascript", transformCode(code));
       }
     }
 
@@ -44,6 +44,7 @@ export const highlightCode = content => {
     return `<pre><code>${renderToString(highlightedNode)}</code></pre>`;
   });
 };
+
 export const substituteVariables = (highlightedContent, variables) =>
   highlightedContent.replace(VARIABLE_SPAN_REGEX, (matchedSpan, dataLabel) => {
     const dataLabelSplitted = dataLabel.split(".");

--- a/src/styles/editor/_editor-content.scss
+++ b/src/styles/editor/_editor-content.scss
@@ -114,6 +114,7 @@
     font-size: inherit;
     font-family: inherit;
     line-height: inherit;
+    white-space: pre-wrap;
   }
 
   // Blockquote


### PR DESCRIPTION
- Fixes #827 

**Description**

- Fixed: styling of code-block
- Added: "plaintext" as default
- Fixed: issues with parsed coodeblock in EditorContent

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
