### PR TITLE
Fixed issues in slash-commands `ExtensionConfig` where reactRenderer becomes undefined

### DIFF
--- a/src/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -98,7 +98,7 @@ export default {
                   });
                 },
                 onKeyDown(props) {
-                  return reactRenderer.ref?.onKeyDown(props);
+                  return reactRenderer && reactRenderer?.ref?.onKeyDown(props);
                 },
                 onExit() {
                   popup && popup[0].destroy();


### PR DESCRIPTION
- Fixes #832 

**Description**

- Fixed: issues in slash-commands `ExtensionConfig` where reactRenderer becomes undefined

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan