### PR TITLE
Updated the onChange method of FormikEditor

### DIFF
--- a/src/components/Editor/FormikEditor.jsx
+++ b/src/components/Editor/FormikEditor.jsx
@@ -1,10 +1,11 @@
 import React, { forwardRef } from "react";
 
 import { FastField } from "formik";
+import { noop } from "neetocommons/pure";
 
 import Editor from ".";
 
-const FormikEditor = ({ name, ...otherProps }, ref) => (
+const FormikEditor = ({ name, onChange = noop, ...otherProps }, ref) => (
   <FastField name={name}>
     {({ field, form, meta }) => (
       <Editor
@@ -13,7 +14,10 @@ const FormikEditor = ({ name, ...otherProps }, ref) => (
         name={name}
         ref={ref}
         onBlur={() => form.setFieldTouched(name, true)}
-        onChange={value => form.setFieldValue(name, value)}
+        onChange={value => {
+          form.setFieldValue(name, value);
+          onChange?.(value);
+        }}
         {...otherProps}
       />
     )}


### PR DESCRIPTION
- Fixes #857 

**Description**

- The `onChange` prop of `FormikEditor` should not override the entire `onChange` method.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
