### PR TITLE
Added prop to control images opening in new tab for preview

### DIFF
--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -32,6 +32,7 @@ export default Node.create({
   addOptions() {
     return {
       HTMLAttributes: {},
+      openImageInNewTab: true,
     };
   },
 
@@ -91,17 +92,22 @@ export default Node.create({
 
   renderHTML({ node, HTMLAttributes }) {
     const { align, src, figheight, figwidth } = node.attrs;
+    const openImageInNewTab = this.options.openImageInNewTab;
 
     const wrapperDivAttrs = {
       class: `neeto-editor__image-wrapper neeto-editor__image--${align}`,
     };
+
+    const wrapperLinkPointerEventsStyle = openImageInNewTab
+      ? ""
+      : "pointer-events:none;";
 
     const wrapperLinkAttrs = {
       href: src,
       target: "_blank",
       rel: "noopener noreferrer",
       class: "neeto-editor__image",
-      style: `height:${figheight}px;width:${figwidth}px;`,
+      style: `height:${figheight}px;width:${figwidth}px;${wrapperLinkPointerEventsStyle}`,
     };
 
     const captionAttrs = { style: `width:${figwidth}px;` };

--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -102,12 +102,13 @@ export default Node.create({
       ? ""
       : "pointer-events:none;";
 
+    const heightStyle = figheight === "auto" ? "auto" : `${figheight}px`;
     const wrapperLinkAttrs = {
       href: src,
       target: "_blank",
       rel: "noopener noreferrer",
       class: "neeto-editor__image",
-      style: `height:${figheight}px;width:${figwidth}px;${wrapperLinkPointerEventsStyle}`,
+      style: `height:${heightStyle};width:${figwidth}px;${wrapperLinkPointerEventsStyle}`,
     };
 
     const captionAttrs = { style: `width:${figwidth}px;` };

--- a/src/components/Editor/CustomExtensions/Video/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Video/ExtensionConfig.js
@@ -65,18 +65,19 @@ const VideoExtension = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    const { align, src, vidheight, vidwidth } = node.attrs;
+    const { align, vidheight, vidwidth } = node.attrs;
 
     const wrapperDivAttrs = {
       class: `neeto-editor__image-wrapper neeto-editor__image--${align}`,
     };
 
+    const heightStyle =
+      vidheight === "fit-content" ? "fit-content" : `${vidheight}px;`;
+
     const wrapperLinkAttrs = {
-      href: src,
-      target: "_blank",
       rel: "noopener noreferrer",
       class: "neeto-editor__image",
-      style: `height:${vidheight}px;width:${vidwidth}px;`,
+      style: `height:${heightStyle};width:${vidwidth}px;`,
     };
 
     const captionAttrs = { style: `width:${vidwidth}px;` };

--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -45,6 +45,7 @@ const useCustomExtensions = ({
   isVideoEmbedActive,
   setMediaUploader,
   setIsEmbedModalOpen,
+  openImageInNewTab,
 }) => {
   let customExtensions = [
     CharacterCount,
@@ -59,7 +60,7 @@ const useCustomExtensions = ({
     Focus.configure({ mode: "shallowest" }),
     Highlight,
     VideoExtension,
-    ImageExtension,
+    ImageExtension.configure({ openImageInNewTab }),
     Link.configure({ autolink: false }),
     Placeholder.configure({ placeholder }),
     StarterKit.configure({ document: false, codeBlock: false, code: false }),

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -61,6 +61,7 @@ const Editor = (
     onChangeAttachments = noop,
     children,
     showAttachmentsToastr = true,
+    openImageInNewTab = true,
     ...otherProps
   },
   ref
@@ -98,6 +99,7 @@ const Editor = (
     setMediaUploader,
     setIsEmbedModalOpen,
     isVideoEmbedActive,
+    openImageInNewTab,
   });
   useEditorWarnings({ initialValue });
 

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -202,4 +202,9 @@ export const EDITOR_PROPS = [
     "showAttachmentsToastr",
     "Accepts a boolean value. If provided, it will show a toast message when the attachments are updated/deleted.",
   ],
+  [
+    "openImageInNewTab",
+    "Accepts a boolean value. When set to 'false', it prevents images from opening in new tabs for preview.",
+    "true",
+  ],
 ];

--- a/types.d.ts
+++ b/types.d.ts
@@ -123,6 +123,7 @@ interface EditorProps {
   onChangeAttachments?: (attachments: attachment[]) => void;
   showAttachmentsToastr?: boolean;
   children?: ReactNode;
+  openImageInNewTab?: boolean;
   [otherProps: string]: any;
 }
 


### PR DESCRIPTION
- Fixes #859 

**Description**

- Added: prop to control images from always opening in new tab
- Updated: ExtensionConfig of Video and Image nodes

**Checklist**

- [x] I have made corresponding changes to the documentation.
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a