### PR TITLE
Added a fallback to javascript for javascriptreact in codeblocks

### DIFF
--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -30,6 +30,8 @@ const CodeBlockComponent = ({ node, updateAttributes }) => {
 
   useEffect(() => {
     isNil(node.attrs?.language) && updateAttributes({ language: "plaintext" });
+    node.attrs?.language === "javascriptreact" &&
+      updateAttributes({ language: "javascript" });
   }, []);
 
   return (

--- a/src/components/EditorContent/constants.js
+++ b/src/components/EditorContent/constants.js
@@ -1,3 +1,5 @@
+import { lowlight } from "lowlight";
+
 export const EDITOR_CONTENT_CLASSNAME = "neeto-editor-content";
 
 export const SANITIZE_OPTIONS = {
@@ -10,3 +12,5 @@ export const CODE_BLOCK_REGEX =
 
 export const VARIABLE_SPAN_REGEX =
   /<span data-variable="" [^>]*data-label="([^"]+)">{{([^}]+)}}<\/span>/g;
+
+export const LANGUAGE_LIST = lowlight.listLanguages();

--- a/src/components/EditorContent/utils.js
+++ b/src/components/EditorContent/utils.js
@@ -6,7 +6,11 @@ import { findBy } from "neetocommons/pure";
 import { isEmpty } from "ramda";
 import { renderToString } from "react-dom/server";
 
-import { CODE_BLOCK_REGEX, VARIABLE_SPAN_REGEX } from "./constants";
+import {
+  CODE_BLOCK_REGEX,
+  LANGUAGE_LIST,
+  VARIABLE_SPAN_REGEX,
+} from "./constants";
 
 const transformCode = code =>
   code.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&");
@@ -28,7 +32,7 @@ export const highlightCode = content => {
   let highlightedAST = {};
 
   return content.replace(CODE_BLOCK_REGEX, (_, language, code) => {
-    if (language) {
+    if (language && LANGUAGE_LIST.includes(language)) {
       highlightedAST = lowlight.highlight(language, transformCode(code));
     } else {
       highlightedAST = hljs.highlightAuto(transformCode(code))._emitter.root;


### PR DESCRIPTION
- Fixes #876 

**Description**

- Fixed: issues with codeblocks when javascriptreact is provided as language
- Added: a fallback to "javascript" for "javascriptreact"

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@adityamahajan-io _a can you verify if this fixes the issue.