### PR TITLE
Fixed issues while parsing `figure without `figcaption` tag

### DIFF
--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -85,7 +85,6 @@ export default Node.create({
     return [
       {
         tag: "figure",
-        contentElement: "figcaption",
       },
     ];
   },


### PR DESCRIPTION
- Fixes #879 

**Description**

- Fixed: issues while parsing `figure` without `figcaption` tag

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@abilash-sajeev _a can you please verify this meets the requirements.