### PR TITLE
Added a new prop "contentAttributes" to receive attributes for `EditorContent`

### DIFF
--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -35,6 +35,7 @@ const Editor = (
     autoFocus = false,
     className,
     contentClassName,
+    contentAttributes = {},
     menuClassName,
     attachmentsClassName,
     isMenuIndependent = false,
@@ -127,6 +128,7 @@ const Editor = (
       attributes: {
         class: editorClasses,
         style: getEditorStyles({ rows }),
+        ...contentAttributes,
       },
       clipboardTextParser,
     },
@@ -161,53 +163,51 @@ const Editor = (
         <Label
           className="neeto-ui-mb-2"
           data-cy={`${slugify(label)}-editor-label`}
-          required={required}
+          {...{ required }}
         >
           {label}
         </Label>
       )}
-      <ErrorWrapper error={error}>
+      <ErrorWrapper {...{ error }}>
         <CharacterCountWrapper
-          editor={editor}
+          {...{ editor }}
           isActive={isCharacterCountActive}
         >
           <Menu
-            addonCommands={addonCommands}
-            addons={addons}
             className={menuClassName}
-            defaults={defaults}
-            editor={editor}
-            editorSecrets={editorSecrets}
-            handleUploadAttachments={handleUploadAttachments}
+            {...{
+              addonCommands,
+              addons,
+              defaults,
+              editor,
+              editorSecrets,
+              handleUploadAttachments,
+              isMenuCollapsible,
+              mentions,
+              menuType,
+              tooltips,
+              variables,
+            }}
             isIndependant={isMenuIndependent}
-            isMenuCollapsible={isMenuCollapsible}
-            mentions={mentions}
-            menuType={menuType}
-            tooltips={tooltips}
-            variables={variables}
           />
           {children}
-          <EditorContent editor={editor} {...otherProps} />
+          <EditorContent {...{ editor, ...otherProps }} />
           {isMediaUploaderActive && (
             <MediaUploader
-              editor={editor}
-              mediaUploader={mediaUploader}
+              {...{ editor, mediaUploader }}
               unsplashApiKey={editorSecrets?.unsplash}
               onClose={() => setMediaUploader({ image: false, video: false })}
             />
           )}
           {isVideoEmbedActive && (
             <EmbedOption
-              editor={editor}
-              isEmbedModalOpen={isEmbedModalOpen}
-              setIsEmbedModalOpen={setIsEmbedModalOpen}
+              {...{ editor, isEmbedModalOpen, setIsEmbedModalOpen }}
             />
           )}
           {isAttachmentsActive && (
             <Attachments
-              attachments={attachments}
+              {...{ attachments, dragDropRef }}
               config={attachmentsConfig}
-              dragDropRef={dragDropRef}
               isIndependent={false}
               ref={addAttachmentsRef}
               showToastr={showAttachmentsToastr}
@@ -217,7 +217,7 @@ const Editor = (
               onChange={onChangeAttachments}
             />
           )}
-          {editor?.isActive("link") && <LinkPopOver editor={editor} />}
+          {editor?.isActive("link") && <LinkPopOver {...{ editor }} />}
         </CharacterCountWrapper>
       </ErrorWrapper>
     </div>

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -90,6 +90,11 @@ export const EDITOR_PROPS = [
     `"neeto-editor-content"`,
   ],
   [
+    "contentAttributes",
+    "Accepts an object. Can be used to add additional attributes to the editor content.",
+    `{ "data-gramm": false }`,
+  ],
+  [
     "uploadConfig",
     "Accepts an object. This object will be used to configure the image uploader.",
     `{

--- a/types.d.ts
+++ b/types.d.ts
@@ -106,6 +106,7 @@ interface EditorProps {
   addonCommands?: Command[];
   className?: string;
   contentClassName?: string;
+  contentAttributes?: { [key: string]: string };
   onChange?: (htmlContent: string) => void;
   onFocus?: EditorFocus;
   onBlur?: EditorFocus;


### PR DESCRIPTION
- Fixes #897 

**Description**

- Added: new prop "contentAttributes" for user to add attributes to `EditorContent`

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@gaagul 
