### PR TITLE
Used globalProps.endUserUploadedFileSizeLimitInMb for standardizing upload size

### DIFF
--- a/src/components/Attachments/constants.js
+++ b/src/components/Attachments/constants.js
@@ -1,14 +1,12 @@
-const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+import { globalProps } from "neetocommons/initializers";
 
 export const DEFAULT_UPPY_CONFIG = {
   autoProceed: false,
   allowMultipleUploads: false,
   restrictions: {
-    maxFileSize: MAX_FILE_SIZE,
+    maxFileSize: globalProps.endUserUploadedFileSizeLimitInMb * 1024 * 1024,
   },
 };
-
-export const UPPY_UPLOAD_CONFIG = { formData: true, fieldName: "blob" };
 
 export const ATTACHMENT_OPTIONS = {
   DOWNLOAD: "Download",

--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -1,6 +1,7 @@
 import { mergeAttributes, Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { t } from "i18next";
+import { globalProps } from "neetocommons/initializers";
 import { Toastr } from "neetoui";
 import { Plugin } from "prosemirror-state";
 import { isEmpty } from "ramda";
@@ -10,19 +11,18 @@ import DirectUpload from "utils/DirectUpload";
 
 import ImageComponent from "./ImageComponent";
 
-import { MAX_IMAGE_SIZE } from "../../MediaUploader/constants";
-
 const upload = async (file, url) => {
-  if (file.size <= MAX_IMAGE_SIZE) {
+  if (file.size <= globalProps.endUserUploadedFileSizeLimitInMb * 1024 * 1024) {
     const uploader = new DirectUpload({ file, url });
     const response = await uploader.create();
 
     return response.data?.blob_url || response.blob_url;
   }
 
-  const imageSizeInMB = MAX_IMAGE_SIZE / (1024 * 1024);
   Toastr.error(
-    t("neetoEditor.error.imageSizeIsShouldBeLess", { limit: imageSizeInMB })
+    t("neetoEditor.error.imageSizeIsShouldBeLess", {
+      limit: globalProps.endUserUploadedFileSizeLimitInMb,
+    })
   );
 
   return "";

--- a/src/components/Editor/MediaUploader/constants.js
+++ b/src/components/Editor/MediaUploader/constants.js
@@ -1,16 +1,16 @@
+import { globalProps } from "neetocommons/initializers";
+
 const MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100 MB
 
 export const ALLOWED_IMAGE_TYPES = [".jpg", ".jpeg", ".png", ".gif"];
 export const ALLOWED_VIDEO_TYPES = [".mp4", ".mov", ".avi", ".mkv"];
-
-export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 export const DEFAULT_IMAGE_UPPY_CONFIG = {
   autoProceed: false,
   allowMultipleUploads: true,
   restrictions: {
     maxNumberOfFiles: 5,
-    maxFileSize: MAX_IMAGE_SIZE,
+    maxFileSize: globalProps.endUserUploadedFileSizeLimitInMb * 1024 * 1024,
     allowedFileTypes: ALLOWED_IMAGE_TYPES,
   },
 };

--- a/src/components/Editor/MediaUploader/utils.js
+++ b/src/components/Editor/MediaUploader/utils.js
@@ -1,7 +1,7 @@
 import { t } from "i18next";
 import { LeftAlign, CenterAlign, RightAlign, Delete } from "neetoicons";
 
-export const convertToFileSize = size => {
+export const convertToFileSize = (size = 10 * 1024 * 1024) => {
   const units = ["B", "KB", "MB", "GB"];
   let i = 0;
   while (size >= 1024 && i < units.length) {

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -99,18 +99,6 @@ export const EDITOR_PROPS = [
     `{ "data-gramm": false }`,
   ],
   [
-    "uploadConfig",
-    "Accepts an object. This object will be used to configure the image uploader.",
-    `{
-      autoProceed: true,
-      allowMultipleUploads: false,
-      restrictions: {
-        maxFileSize: 1048576,
-        allowedFileTypes: [".jpg"]
-      },
-    }`,
-  ],
-  [
     "onChange",
     "Accepts a function. This function will be invoked whenever the editor content changes, with the new content as argument.",
     `(newContent) => {}`,

--- a/stories/Examples/Customize-options/Image-upload.stories.mdx
+++ b/stories/Examples/Customize-options/Image-upload.stories.mdx
@@ -100,35 +100,15 @@ Unsplash image picker. Pass the Unsplash access key to the editor via the
 
 ### **Upload configuration**
 
-neetoEditor provides an option edit the upload configuration. The configuration
-can be passed as a prop to the editor. The default configuration is:
+The default configuration for uploads is:
 
 ```json
 {
   autoProceed: true,
   allowMultipleUploads: false,
   restrictions: {
-    maxFileSize: 5242880, // 5MB
+    maxFileSize: globalProps.endUserUploadedFileSizeLimitInMb,
     allowedFileTypes: [".jpg", ".jpeg", ".png", ".gif"]],
   },
 }
 ```
-
-This can be overridden by passing the `uploadConfig` prop. Refer
-[Uppy official documentation](https://uppy.io/docs/uppy/#Options) for the list
-of available options.
-
-<Canvas>
-  <Editor
-    addons={["image-upload"]}
-    uploadConfig={{
-      autoProceed: true,
-      allowMultipleUploads: false,
-      restrictions: {
-        maxFileSize: 1 * 1024 * 1024, // 1 MB
-        allowedFileTypes: [".jpg", ".jpeg"],
-      },
-    }}
-    defaults={[]}
-  />
-</Canvas>

--- a/stories/Examples/constants.js
+++ b/stories/Examples/constants.js
@@ -29,18 +29,6 @@ export const MENU_PROPS = [
     `"neeto-editor-content"`,
   ],
   [
-    "uploadConfig",
-    "Accepts an object. This object will be used to configure the image uploader.",
-    `{
-      autoProceed: true,
-      allowMultipleUploads: false,
-      restrictions: {
-        maxFileSize: 1048576,
-        allowedFileTypes: [".jpg"]
-      },
-    }`,
-  ],
-  [
     "variables",
     "Accepts an array of variable suggestions.",
     `[{ label: "Subdomain", key: "subdomain" }]`,


### PR DESCRIPTION
- Fixes #924

**Description**

- Used globalProps.endUserUploadedFileSizeLimitInMb for standardizing upload size

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
patch _t

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
