### PR TITLE
Removed axios from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "@bigbinary/neetoui": "latest",
     "@honeybadger-io/react": "2.0.1",
     "antd": "4.24.3",
-    "axios": "0.27.2",
     "formik": "2.2.9",
     "i18next": "23.2.7",
     "js-logger": "^1.6.1",


### PR DESCRIPTION
Ref: https://github.com/bigbinary/neeto-chat-web/issues/9021

- Temporarily removed axios from peer dependencies.
- This will bundle the axios version 0.27.0 with the neetoEditor bundle.

@AbhayVAshokan _a
patch _t