### PR TITLE
Added contentType to DocViewer

### DIFF
--- a/src/components/Attachments/Preview.jsx
+++ b/src/components/Attachments/Preview.jsx
@@ -64,7 +64,7 @@ const Preview = ({
           return (
             <DocViewer
               className="h-full w-full"
-              documents={[{ uri: url }]}
+              documents={[{ uri: url, fileType: contentType }]}
               pluginRenderers={[PDFRenderer, TXTRenderer]}
               config={{
                 header: { disableHeader: true, disableFileName: true },


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-editor-engine/issues/267

**Description**

- Added `fileType` to DocViewer component to make sure that the request does not return a 403 status.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@AbhayVAshokan _a
patch _t

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
