### PR TITLE
Added option to customize error wrapper

### DIFF
--- a/src/components/Common/ErrorWrapper.jsx
+++ b/src/components/Common/ErrorWrapper.jsx
@@ -5,9 +5,12 @@ import { is } from "ramda";
 
 import { isNilOrEmpty } from "utils/common";
 
-const ErrorWrapper = ({ error, children }) => {
+const ErrorWrapper = ({ error, children, className }) => {
   const isError = !isNilOrEmpty(error);
-  const wrapperClasses = classnames({ "neeto-editor-error": isError });
+  const wrapperClasses = classnames({
+    "neeto-editor-error": isError,
+    [className]: className,
+  });
 
   const getErrorMessage = () => {
     if (!error) return null;

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -35,6 +35,7 @@ const Editor = (
     autoFocus = false,
     className,
     contentClassName,
+    errorWrapperClassName,
     contentAttributes = {},
     menuClassName,
     attachmentsClassName,
@@ -171,7 +172,7 @@ const Editor = (
           {label}
         </Label>
       )}
-      <ErrorWrapper {...{ error }}>
+      <ErrorWrapper className={errorWrapperClassName} {...{ error }}>
         <CharacterCountWrapper
           {...{ editor }}
           isActive={isCharacterCountActive}

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -180,6 +180,11 @@ export const EDITOR_PROPS = [
     "This field is required",
   ],
   [
+    "errorWrapperClassName",
+    "Accepts a string value. Can be used for further customisation of the error wrapper layout.",
+    `"neeto-editor-error-wrapper"`,
+  ],
+  [
     "attachments",
     "Accepts an array of attachment objects. This array will be used to display the attachments in the editor.",
   ],

--- a/types.d.ts
+++ b/types.d.ts
@@ -94,6 +94,7 @@ interface EditorProps {
   isMenuCollapsible?: boolean;
   menuClassName?: string;
   attachmentsClassName?: string;
+  errorWrapperClassName?: string;
   tooltips?: tooltips;
   initialValue?: string;
   menuType?: "fixed" | "bubble" | "headless" | "none";


### PR DESCRIPTION
- Fixes #962 

**Description**

- Added: option to override error wrapper styles

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@gaagul _a