### PR TITLE
Adds anycase to the file size error message translator.

### DIFF
--- a/src/components/Editor/MediaUploader/constants.js
+++ b/src/components/Editor/MediaUploader/constants.js
@@ -2,6 +2,8 @@ import { globalProps } from "neetocommons/initializers";
 
 const MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100 MB
 
+export const FILE_SIZE_UNITS = ["B", "KB", "MB", "GB"];
+
 export const ALLOWED_IMAGE_TYPES = [".jpg", ".jpeg", ".png", ".gif"];
 export const ALLOWED_VIDEO_TYPES = [".mp4", ".mov", ".avi", ".mkv"];
 

--- a/src/components/Editor/MediaUploader/utils.js
+++ b/src/components/Editor/MediaUploader/utils.js
@@ -1,15 +1,17 @@
 import { t } from "i18next";
 import { LeftAlign, CenterAlign, RightAlign, Delete } from "neetoicons";
 
+import { FILE_SIZE_UNITS } from "./constants";
+
 export const convertToFileSize = (size = 10 * 1024 * 1024) => {
-  const units = ["B", "KB", "MB", "GB"];
+  let fileSize = size;
   let i = 0;
-  while (size >= 1024 && i < units.length) {
-    size /= 1024;
+  while (fileSize >= 1024 && i < FILE_SIZE_UNITS.length) {
+    fileSize /= 1024;
     ++i;
   }
 
-  return `${size.toFixed(1)} ${units[i]}`;
+  return `${fileSize.toFixed(1)} ${FILE_SIZE_UNITS[i]}`;
 };
 
 export const buildImageOptions = () => [

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -30,7 +30,7 @@
       "invalidUrl": "Please enter a valid URL",
       "cannotAddFiles": "Cannot add files",
       "onBeforeFileAddedReturn": "Cannot add the file because onBeforeFileAdded returned false.",
-      "fileIsTooLarge": "File size is too large. Max size is {{maxFileSize}}.",
+      "fileIsTooLarge": "File size is too large. Max size is {{maxFileSize, anyCase}}.",
       "imageSizeIsShouldBeLess": "Image size should be less than {{limit}} MB",
       "urlRequired": "URL is required",
       "textRequired": "Text is required"


### PR DESCRIPTION
Fixes #964 

**Description**
Adds `anyCase` transformer in the file size error message so that the unit is not rendered in lower case.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@AbhayVAshokan 

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
