### PR TITLE
Added removeEmptyTags utility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,11 @@ import {
   isEmojiSuggestionsMenuActive,
 } from "components/Editor/utils";
 import { substituteVariables } from "components/EditorContent/utils";
-import { isEditorEmpty, isEditorContentWithinLimit } from "utils/common";
+import {
+  isEditorEmpty,
+  isEditorContentWithinLimit,
+  removeEmptyTags,
+} from "utils/common";
 
 import Attachments from "./components/Attachments";
 import Editor from "./components/Editor";
@@ -18,6 +22,7 @@ export {
   Editor,
   EditorContent,
   Menu,
+  removeEmptyTags,
   isEditorEmpty,
   isEditorContentWithinLimit,
   substituteVariables,

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,6 +1,48 @@
 import { isNotPresent } from "neetocist";
 
-import { NON_EMPTY_TAGS } from "./constants";
+import { EMPTY_TAGS_TO_REMOVE, NON_EMPTY_TAGS } from "./constants";
+
+const removeTagsStart = node => {
+  while (
+    node.firstChild &&
+    EMPTY_TAGS_TO_REMOVE.includes(node.firstChild.tagName?.toLowerCase())
+  ) {
+    if (!node.firstChild.innerHTML) {
+      node.firstChild.remove();
+    } else {
+      removeTagsStart(node.firstChild);
+      if (node.firstChild.innerHTML) {
+        break;
+      }
+    }
+  }
+};
+
+const removeTagsEnd = node => {
+  while (
+    node.lastChild &&
+    EMPTY_TAGS_TO_REMOVE.includes(node.lastChild.tagName?.toLowerCase())
+  ) {
+    if (!node.lastChild.innerHTML) {
+      node.lastChild.remove();
+    } else {
+      removeTagsEnd(node.lastChild);
+      if (node.lastChild.innerHTML) {
+        break;
+      }
+    }
+  }
+};
+
+export const removeEmptyTags = html => {
+  const tempDiv = document.createElement("div");
+  tempDiv.innerHTML = html;
+
+  removeTagsStart(tempDiv);
+  removeTagsEnd(tempDiv);
+
+  return tempDiv.innerHTML;
+};
 
 export const isEditorEmpty = htmlContent => {
   if (isNotPresent(htmlContent)) return true;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,14 @@
 export const NON_EMPTY_TAGS = ["img", "iframe"];
 
 export const MARGIN_HEIGHT = 8;
+
+export const EMPTY_TAGS_TO_REMOVE = [
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "br",
+];

--- a/types.d.ts
+++ b/types.d.ts
@@ -161,6 +161,8 @@ export function EditorContent(props: {
 
 export function Menu(props: MenuProps): JSX.Element;
 
+export function removeEmptyTags(html: string): string;
+
 export function isEditorEmpty(htmlContent: string | null | undefined): boolean;
 
 export function isEditorContentWithinLimit(htmlContent: string | null | undefined, maxLength: number): boolean;


### PR DESCRIPTION
- Fixes #977 

**Description**
Added a utility function `removeEmptyTags` that removes empty lines from the beginning and ends of the editor content. Any HTML content can be passed to the method and it returns a cleaned-up version of the HTML

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).