### PR TITLE
Fixed interference between the settings of inserting link the default way and new markdown structure

### DIFF
--- a/src/components/Editor/CustomExtensions/Link/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Link/ExtensionConfig.js
@@ -1,15 +1,7 @@
-import {
-  InputRule,
-  markInputRule,
-  markPasteRule,
-  PasteRule,
-} from "@tiptap/core";
+import { InputRule, markInputRule } from "@tiptap/core";
 import { Link } from "@tiptap/extension-link";
 
-import {
-  LINK_MARKDOWN_INPUT_REGEX,
-  LINK_MARKDOWN_PASTE_REGEX,
-} from "./constants";
+import { LINK_MARKDOWN_INPUT_REGEX } from "./constants";
 
 const linkInputRule = config => {
   const defaultMarkInputRule = markInputRule(config);
@@ -25,20 +17,6 @@ const linkInputRule = config => {
   });
 };
 
-const linkPasteRule = config => {
-  const defaultMarkPasteRule = markPasteRule(config);
-
-  return new PasteRule({
-    find: config.find,
-    handler(props) {
-      const { tr } = props.state;
-
-      defaultMarkPasteRule.handler(props);
-      tr.setMeta("preventAutolink", true);
-    },
-  });
-};
-
 export default Link.extend({
   inclusive: false,
   addAttributes() {
@@ -48,20 +26,6 @@ export default Link.extend({
     return [
       linkInputRule({
         find: LINK_MARKDOWN_INPUT_REGEX,
-        type: this.type,
-        getAttributes(match) {
-          return {
-            title: match.pop()?.trim(),
-            href: match.pop()?.trim(),
-          };
-        },
-      }),
-    ];
-  },
-  addPasteRules() {
-    return [
-      linkPasteRule({
-        find: LINK_MARKDOWN_PASTE_REGEX,
         type: this.type,
         getAttributes(match) {
           return {

--- a/src/components/Editor/CustomExtensions/Link/constants.js
+++ b/src/components/Editor/CustomExtensions/Link/constants.js
@@ -1,4 +1,2 @@
 export const LINK_MARKDOWN_INPUT_REGEX =
   /(?:^|\s)\[([^\]]*)?\]\((\S+)(?: ["“](.+)["”])?\)$/i;
-export const LINK_MARKDOWN_PASTE_REGEX =
-  /(?:^|\s)\[([^\]]*)?\]\((\S+)(?: ["“](.+)["”])?\)/gi;


### PR DESCRIPTION
- Fixes #1001 

**Description**

- Fixed: Issues in `Link` extension

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@gaagul _a