### PR TITLE
Fixed issues with escape key not closing media uploader modal

### DIFF
--- a/src/components/Editor/MediaUploader/index.jsx
+++ b/src/components/Editor/MediaUploader/index.jsx
@@ -50,13 +50,16 @@ const MediaUploader = ({ mediaUploader, onClose, editor, unsplashApiKey }) => {
       .run();
   };
 
+  const handleKeydown = event =>
+    not(isUploading) && event.key === "Escape" && handleClose();
+
   return (
     <Modal
       closeButton={false}
       {...{ isOpen }}
-      closeOnEsc={not(isUploading)}
       closeOnOutsideClick={not(isUploading)}
       onClose={handleClose}
+      onKeyDown={handleKeydown}
     >
       <div className="ne-media-uploader">
         {!isNotPresent(tabs) && (


### PR DESCRIPTION
- Fixes #1012 

**Description**

- Fixed: issues with escape key not closing media uploader modal

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@gaagul _a
