### PR TITLE
Sets min-width to the emoji picker container to prevent width changes and placement problems once the content is loaded.

### DIFF
--- a/src/components/Editor/CustomExtensions/Emoji/EmojiPicker/EmojiPickerMenu.jsx
+++ b/src/components/Editor/CustomExtensions/Emoji/EmojiPicker/EmojiPickerMenu.jsx
@@ -53,7 +53,13 @@ class EmojiPickerMenu extends React.Component {
   };
 
   render() {
-    return <div data-cy="neeto-editor-emoji-picker" ref={this.ref} />;
+    return (
+      <div
+        data-cy="neeto-editor-emoji-picker"
+        ref={this.ref}
+        style={{ minWidth: "350px" }}
+      />
+    );
   }
 }
 


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-molecules/issues/1153

**Description**
The emoji picker was misplaced the first time because the container width changes when the emojis are loaded. A min-width is added to fix this issue.

##### Before
![emoji-picker-before](https://github.com/bigbinary/neeto-editor/assets/8749438/ca36ed8b-ca25-491f-b3e3-f076411a3af8)

##### After
![emoji-picker-after](https://github.com/bigbinary/neeto-editor/assets/8749438/5d72a863-4d5d-40bd-9dcb-3eb3681ee8fe)

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
