### PR TITLE
Removed Toastrs from Attachments

### DIFF
--- a/src/apis/direct_uploads.js
+++ b/src/apis/direct_uploads.js
@@ -15,19 +15,19 @@ const create = (url, file, config) =>
     showToastr: false,
   });
 
-const update = ({ signedId, payload, showToastr = true }) =>
+const update = ({ signedId, payload }) =>
   axios.patch(`/api/direct_uploads/${signedId}/`, payload, {
     transformRequestCase: false,
     transformResponseCase: false,
-    showToastr,
+    showToastr: false,
   });
 
-const destroy = (signedId, showToastr = true) =>
-  axios.delete(`/api/direct_uploads/${signedId}`, { showToastr });
+const destroy = signedId =>
+  axios.delete(`/api/direct_uploads/${signedId}`, { showToastr: false });
 
-const attach = (payload, showToastr = true) =>
+const attach = payload =>
   axios.post("/neeto_editor/api/v1/direct_uploads/attach", payload, {
-    showToastr,
+    showToastr: false,
   });
 
 const directUploadsApi = { generate, create, update, destroy, attach };

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -29,7 +29,6 @@ const Attachment = ({
   disabled,
   onChange,
   setSelectedAttachment,
-  showToastr,
 }) => {
   const { t } = useTranslation();
 
@@ -50,11 +49,7 @@ const Attachment = ({
         data: {
           blob: { filename },
         },
-      } = await directUploadsApi.update({
-        signedId,
-        payload,
-        showToastr,
-      });
+      } = await directUploadsApi.update({ signedId, payload });
 
       onChange(
         attachments.map(attachment =>
@@ -75,7 +70,7 @@ const Attachment = ({
     setIsDeleting(true);
     try {
       const { signedId } = attachment;
-      await directUploadsApi.destroy(signedId, showToastr);
+      await directUploadsApi.destroy(signedId);
       onChange(removeBy({ signedId }, attachments));
     } catch (error) {
       Toastr.error(error);

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -33,6 +33,7 @@ const Attachment = ({
   const { t } = useTranslation();
 
   const [isRenaming, setIsRenaming] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [newFilename, setNewFilename] = useState("");
@@ -42,14 +43,12 @@ const Attachment = ({
 
   const handleRename = async () => {
     try {
+      setIsUpdating(true);
       const { signedId } = attachment;
       const payload = { blob: { filename: newFilename } };
 
-      const {
-        data: {
-          blob: { filename },
-        },
-      } = await directUploadsApi.update({ signedId, payload });
+      const response = await directUploadsApi.update({ signedId, payload });
+      const filename = response.data?.blob?.filename || response.blob.filename;
 
       onChange(
         attachments.map(attachment =>
@@ -62,6 +61,7 @@ const Attachment = ({
       Toastr.error(error);
     } finally {
       setIsRenaming(false);
+      setIsUpdating(false);
       setNewFilename("");
     }
   };
@@ -138,6 +138,7 @@ const Attachment = ({
             <Button
               data-cy="neeto-editor-preview-rename-cancel-button"
               icon={Close}
+              loading={isUpdating}
               size="small"
               style="text"
               onClick={() => setIsRenaming(false)}

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -23,7 +23,6 @@ const Attachments = (
     disabled = false,
     dragDropRef = null,
     config = {},
-    showToastr = true,
     setIsUploading = noop,
   },
   ref
@@ -167,7 +166,6 @@ const Attachments = (
               disabled,
               onChange,
               setSelectedAttachment,
-              showToastr,
             }}
             key={attachment.signedId}
           />

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -63,7 +63,6 @@ const Editor = (
     onSubmit = noop,
     onChangeAttachments = noop,
     children,
-    showAttachmentsToastr = true,
     openImageInNewTab = true,
     openLinkInNewTab = true,
     ...otherProps
@@ -227,7 +226,6 @@ const Editor = (
               isIndependent={false}
               ref={addAttachmentsRef}
               setIsUploading={setIsAttachmentsUploading}
-              showToastr={showAttachmentsToastr}
               className={classnames("ne-attachments--integrated", {
                 [attachmentsClassName]: attachmentsClassName,
               })}

--- a/stories/API-Reference/constants.js
+++ b/stories/API-Reference/constants.js
@@ -193,10 +193,6 @@ export const EDITOR_PROPS = [
     `,
   ],
   [
-    "showAttachmentsToastr",
-    "Accepts a boolean value. If provided, it will show a toast message when the attachments are updated/deleted.",
-  ],
-  [
     "openImageInNewTab",
     "Accepts a boolean value. When set to 'false', it prevents images from opening in new tabs for preview.",
     "true",

--- a/types.d.ts
+++ b/types.d.ts
@@ -123,7 +123,6 @@ interface EditorProps {
   error?: string;
   attachments?: Array<attachment>;
   onChangeAttachments?: (attachments: attachment[]) => void;
-  showAttachmentsToastr?: boolean;
   children?: ReactNode;
   openImageInNewTab?: boolean;
   openLinkInNewTab?: boolean;


### PR DESCRIPTION
- Fixes #1101 

**Description**

- Removed Toastrs from Attachments.
- Removed the `showAttachmentsToastr` prop.
- Fixed issues with rename and added a loader for better UX.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

minor _t 
@AbhayVAshokan _a

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
