### PR TITLE
Reduces the bundle size of attachments preview.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 
 # production
 /build
+/dist/*.js
+/dist/*.map
+/dist/editor-stats.html
 /dist/editor-output.js
 /dist/editor-output.js.map
 /dist/codeBlockHighlight.js.map
@@ -26,8 +29,6 @@ yarn-debug.log*
 yarn-error.log*
 
 /editor-content.js
-/index.js
-/index.cjs.js
-/index.*.map
+/index.*
 /formik.js
 storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /build
 /dist/*.js
 /dist/*.map
-/dist/editor-stats.html
 /dist/editor-output.js
 /dist/editor-output.js.map
 /dist/codeBlockHighlight.js.map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.32.1-beta1",
+  "version": "1.33.3",
   "main": "./index.cjs.js",
   "module": "./index.js",
   "types": "./types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.33.3",
+  "version": "1.32.0-beta1",
   "main": "./index.cjs.js",
   "module": "./index.js",
   "types": "./types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.32.0-beta1",
+  "version": "1.32.1-beta1",
   "main": "./index.cjs.js",
   "module": "./index.js",
   "types": "./types.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "index.*",
     "types.d.ts",
-    "src/translations"
+    "src/translations",
+    "dist"
   ],
   "author": "BigBinary",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ import { mergeDeepLeft } from "ramda";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import styles from "rollup-plugin-styles";
 import copy from "rollup-plugin-copy";
+import cleaner from 'rollup-plugin-cleaner';
 
 import packageJson from "./package.json";
 
@@ -21,6 +22,8 @@ const { alias: aliasEntries } = mergeDeepLeft(projectResolve, commonResolve);
 const peerDependencies = Object.keys(packageJson.peerDependencies);
 
 const formats = ["esm", "cjs"];
+
+const cleanerTargets = ['./dist/', "index.cjs.js", "index.js", "index.cjs.js.map", "index.js.map"];
 
 const plugins = [
   peerDepsExternal(),
@@ -65,7 +68,9 @@ const config = args => {
       input: "./src/index.js",
       external: peerDependencies,
       output,
-      plugins: [ ...plugins,
+      plugins: [
+        cleaner({ targets: cleanerTargets }),
+        ...plugins,
         args.app && copy({
           targets: [
             { src: "package.json", dest: destination },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ const peerDependencies = Object.keys(packageJson.peerDependencies);
 
 const formats = ["esm", "cjs"];
 
-const cleanerTargets = ['./dist/', "index.cjs.js", "index.js", "index.cjs.js.map", "index.js.map"];
+const cleanerTargets = ["./dist/", "index.cjs.js", "index.js", "index.cjs.js.map", "index.js.map"];
 
 const plugins = [
   peerDepsExternal(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,8 @@ const config = args => {
     const output = formats.map(format => ({
       assetFileNames: "[name][extname]",
       dir: path.join(destination),
-      entryFileNames: format === "esm" ? "index.js" : "index.cjs.js",
+      entryFileNames: format === "esm" ? 'index.js' : 'index.cjs.js',
+      chunkFileNames: format === "esm" ? 'dist/chunk-[hash].js' : 'dist/chunk-[hash].cjs.js',
       format,
       name: "NeetoEditor",
       sourcemap: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ import { mergeDeepLeft } from "ramda";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import styles from "rollup-plugin-styles";
 import copy from "rollup-plugin-copy";
-import cleaner from 'rollup-plugin-cleaner';
+import cleaner from "rollup-plugin-cleaner";
 
 import packageJson from "./package.json";
 
@@ -56,8 +56,8 @@ const config = args => {
     const output = formats.map(format => ({
       assetFileNames: "[name][extname]",
       dir: path.join(destination),
-      entryFileNames: format === "esm" ? 'index.js' : 'index.cjs.js',
-      chunkFileNames: format === "esm" ? 'dist/chunk-[hash].js' : 'dist/chunk-[hash].cjs.js',
+      entryFileNames: format === "esm" ? "index.js" : "index.cjs.js",
+      chunkFileNames: format === "esm" ? "dist/chunk-[hash].js" : "dist/chunk-[hash].cjs.js",
       format,
       name: "NeetoEditor",
       sourcemap: true,

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -6,6 +6,7 @@ import { MenuVertical, Close } from "neetoicons";
 import {
   Dropdown,
   Input,
+  Spinner,
   Toastr,
   Tooltip,
   Typography,
@@ -29,6 +30,7 @@ const Attachment = ({
   disabled,
   onChange,
   setSelectedAttachment,
+  isLoading,
 }) => {
   const { t } = useTranslation();
 
@@ -154,6 +156,7 @@ const Attachment = ({
               <Tooltip content={attachment.filename} position="top">
                 <Typography style="body2">{attachment.filename}</Typography>
               </Tooltip>
+              {isLoading && <Spinner className="attachment-button-loader" />}
             </div>
             <Tooltip
               content={t("neetoEditor.attachments.actionsBlocked")}

--- a/src/components/Attachments/Preview.jsx
+++ b/src/components/Attachments/Preview.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 
 import { findIndexBy, truncate } from "neetocist";
 import { Left, Right } from "neetoicons";
@@ -17,6 +17,7 @@ const Preview = ({
   attachments,
   selectedAttachment,
   setSelectedAttachment,
+  setDidFetchPreviewBundle,
 }) => {
   const { t } = useTranslation();
   const downloadRef = useRef(null);
@@ -51,6 +52,10 @@ const Preview = ({
       handleLeftArrowClick();
     }
   };
+
+  useEffect(() => {
+    setDidFetchPreviewBundle(true);
+  }, []);
 
   const handleDownload = () => downloadFile(url, filename);
 

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -39,6 +39,7 @@ const Attachments = (
 
   const [pendingAttachments, setPendingAttachments] = useState([]);
   const [selectedAttachment, setSelectedAttachment] = useState({});
+  const [didFetchPreviewBundle, setDidFetchPreviewBundle] = useState(false);
 
   const attachmentInputRef = useRef(null);
 
@@ -176,6 +177,10 @@ const Attachments = (
               setSelectedAttachment,
             }}
             key={attachment.signedId}
+            isLoading={
+              !didFetchPreviewBundle &&
+              selectedAttachment.url === attachment.url
+            }
           />
         ))}
         {pendingAttachments.map(attachment => (
@@ -208,7 +213,12 @@ const Attachments = (
         <Suspense fallback={<span />}>
           {isPresent(selectedAttachment) && (
             <Preview
-              {...{ attachments, selectedAttachment, setSelectedAttachment }}
+              {...{
+                attachments,
+                selectedAttachment,
+                setDidFetchPreviewBundle,
+                setSelectedAttachment,
+              }}
               onClose={() => setSelectedAttachment({})}
             />
           )}

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -9,7 +9,7 @@ import React, {
 
 import DropTarget from "@uppy/drop-target";
 import classnames from "classnames";
-import { removeById, noop } from "neetocist";
+import { isPresent, removeById, noop } from "neetocist";
 import { Button, Toastr } from "neetoui";
 import { concat, isEmpty, isNil } from "ramda";
 import { useTranslation } from "react-i18next";
@@ -206,10 +206,12 @@ const Attachments = (
           onClick={handleFileInputClick}
         />
         <Suspense fallback={<span />}>
-          <Preview
-            {...{ attachments, selectedAttachment, setSelectedAttachment }}
-            onClose={() => setSelectedAttachment({})}
-          />
+          {isPresent(selectedAttachment) && (
+            <Preview
+              {...{ attachments, selectedAttachment, setSelectedAttachment }}
+              onClose={() => setSelectedAttachment({})}
+            />
+          )}
         </Suspense>
       </div>
     </div>

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -1,4 +1,11 @@
-import React, { useRef, useEffect, useState, useImperativeHandle } from "react";
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useImperativeHandle,
+  lazy,
+  Suspense,
+} from "react";
 
 import DropTarget from "@uppy/drop-target";
 import classnames from "classnames";
@@ -11,8 +18,9 @@ import useUppyUploader from "hooks/useUppyUploader";
 
 import Attachment from "./Attachment";
 import AttachmentProgress from "./AttachmentProgress";
-import Preview from "./Preview";
 import { buildUppyConfig, handleDrop, selectFiles } from "./utils";
+
+const Preview = lazy(() => import("./Preview"));
 
 const Attachments = (
   {
@@ -197,10 +205,12 @@ const Attachments = (
           onChange={handleAddFile}
           onClick={handleFileInputClick}
         />
-        <Preview
-          {...{ attachments, selectedAttachment, setSelectedAttachment }}
-          onClose={() => setSelectedAttachment({})}
-        />
+        <Suspense fallback={<span />}>
+          <Preview
+            {...{ attachments, selectedAttachment, setSelectedAttachment }}
+            onClose={() => setSelectedAttachment({})}
+          />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/styles/components/_attachments.scss
+++ b/src/styles/components/_attachments.scss
@@ -156,6 +156,11 @@
       }
     }
   }
+
+  .attachment-button-loader {
+    scale: 0.5;
+    width: 26px !important;
+  }
 }
 
 .ne-attachments--integrated {


### PR DESCRIPTION
Fixes #1124 

**Description**
- Lazy loads the Preview component so that the initial bundle size is low.
- Demo - https://deepak-jose.neetorecord.com/recordings/f0de9964-57c6-4af1-a568-a18e728ecf99
- Review app integrated with these changes - https://neeto-kb-web-k9le-pr-6304.neetodeployapp.com/

<img width="1611" alt="image" src="https://github.com/bigbinary/neeto-editor/assets/8749438/d02af06b-57ce-435b-be80-52431518f1b1">

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
