### PR TITLE
Adds ability to handle the slash command visibility when using bubble menu type.

### DIFF
--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -79,7 +79,8 @@ const Editor = (
     addons.includes(EDITOR_OPTIONS.VIDEO_UPLOAD);
   const isFixedMenuActive = menuType === "fixed";
   const isBubbleMenuActive = menuType === "bubble";
-  const isSlashCommandsActive = !hideSlashCommands && isBubbleMenuActive;
+  const isSlashCommandsActive =
+    !hideSlashCommands || (isBubbleMenuActive && !hideSlashCommands);
   const isPlaceholderActive = !!placeholder;
   const [isEmbedModalOpen, setIsEmbedModalOpen] = useState(false);
   const [mediaUploader, setMediaUploader] = useState({

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -79,7 +79,7 @@ const Editor = (
     addons.includes(EDITOR_OPTIONS.VIDEO_UPLOAD);
   const isFixedMenuActive = menuType === "fixed";
   const isBubbleMenuActive = menuType === "bubble";
-  const isSlashCommandsActive = !hideSlashCommands || isBubbleMenuActive;
+  const isSlashCommandsActive = !hideSlashCommands && isBubbleMenuActive;
   const isPlaceholderActive = !!placeholder;
   const [isEmbedModalOpen, setIsEmbedModalOpen] = useState(false);
   const [mediaUploader, setMediaUploader] = useState({

--- a/stories/Walkthroughs/Menu-types/SlashCommand.stories.mdx
+++ b/stories/Walkthroughs/Menu-types/SlashCommand.stories.mdx
@@ -19,7 +19,7 @@ import Bubble from "../../assets/slash-command.mp4";
 # Slash Commands
 
 Slash commands are actions that can be applied to block of text. This menu is
-disable by default, setting the prop `hideSlashCommands` to `false` will enable
+disabled by default. Setting the prop `hideSlashCommands` to `false` will enable
 this menu and appears when user types `/` at start of new line.
 
 <video src={Bubble} playsinline autoPlay muted loop />


### PR DESCRIPTION
Part of https://github.com/bigbinary/neeto-quiz-web/issues/4132

**Description**
Adds ability to hide the slash command visibility when using bubble menu.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
