### PR TITLE
Wraps the defaultMarkInputRule.handler in a try catch block to catch unexpected RangeError.

### DIFF
--- a/src/components/Editor/CustomExtensions/Link/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Link/ExtensionConfig.js
@@ -9,10 +9,14 @@ const linkInputRule = config => {
   return new InputRule({
     find: config.find,
     handler(props) {
-      const { tr } = props.state;
-
-      defaultMarkInputRule.handler(props);
-      tr.setMeta("preventAutolink", true);
+      try {
+        const { tr } = props.state;
+        defaultMarkInputRule.handler(props);
+        tr.setMeta("preventAutolink", true);
+      } catch (error) {
+        // https://app.honeybadger.io/projects/94805/faults/108936285
+        if (!(error instanceof RangeError)) throw error;
+      }
     },
   });
 };


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-kb-web/issues/6441

**Description**
Since the error is from the TipTap internal logic there's nothing much we can do except catch the error.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
