### PR TITLE
Fixes the error: flushSync was called from inside a lifecycle method.

### DIFF
--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -27,9 +27,10 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
   };
 
   useEffect(() => {
-    isNil(node.attrs?.language) && updateAttributes({ language: "plaintext" });
-    node.attrs?.language === "javascriptreact" &&
-      updateAttributes({ language: "javascript" });
+    if (isNil(node.attrs?.language)) {
+      // https://github.com/bigbinary/neeto-kb-web/issues/6429
+      setTimeout(() => updateAttributes({ language: "plaintext" }), 0);
+    }
   }, []);
 
   return (


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-kb-web/issues/6429

**Description**
Before
![editor-reading-size-issue-before](https://github.com/bigbinary/neeto-editor/assets/8749438/bf043eea-14e0-43c2-a300-1831c736ccc0)

After
![editor-reading-size-issue-after](https://github.com/bigbinary/neeto-editor/assets/8749438/026fd8ed-d6b1-4c42-b978-5d5f5f08e967)

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
