### PR TITLE
Added data-cy label to SecondaryMenuTarget

### DIFF
--- a/src/components/Editor/Menu/Fixed/components/EmojiOption.jsx
+++ b/src/components/Editor/Menu/Fixed/components/EmojiOption.jsx
@@ -21,6 +21,7 @@ const EmojiOption = ({
     dropdownProps={{ classNames: "neeto-editor-fixed-menu__emoji-dropdown" }}
     icon={Smiley}
     isOpen={isActive}
+    label="emoji"
     position={isSecondaryMenu ? "left-start" : "bottom-start"}
     strategy="fixed"
     buttonProps={{

--- a/src/components/Editor/Menu/Fixed/components/EmojiOption.jsx
+++ b/src/components/Editor/Menu/Fixed/components/EmojiOption.jsx
@@ -21,13 +21,13 @@ const EmojiOption = ({
     dropdownProps={{ classNames: "neeto-editor-fixed-menu__emoji-dropdown" }}
     icon={Smiley}
     isOpen={isActive}
-    label="emoji"
     position={isSecondaryMenu ? "left-start" : "bottom-start"}
     strategy="fixed"
     buttonProps={{
       tabIndex: -1,
       tooltipProps: { content: tooltipContent ?? label, position: "bottom" },
       className: "neeto-editor-fixed-menu__item",
+      "data-cy": "neeto-editor-fixed-menu-emoji-option",
     }}
     customTarget={
       isSecondaryMenu && <SecondaryMenuTarget {...{ label }} icon={Smiley} />

--- a/src/components/Editor/Menu/Fixed/components/SecondaryMenuTarget.jsx
+++ b/src/components/Editor/Menu/Fixed/components/SecondaryMenuTarget.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 
+import { hyphenate } from "neetocist";
 import { Dropdown } from "neetoui";
 
 const { MenuItem } = Dropdown;
 
 const SecondaryMenuTarget = ({ icon: Icon, label }) => (
-  <MenuItem.Button>
+  <MenuItem.Button
+    data-cy={`neeto-editor-fixed-menu-${hyphenate(label)}-option`}
+  >
     <Icon /> {label}
   </MenuItem.Button>
 );


### PR DESCRIPTION
- Fixes #1168

**Description**
 Added data-cy label to SecondaryMenuTarget component.
 Added label to Dropdown in EmojiOption to add the data-cy label to Dropdown.

**Checklist**

- [x] ~~I have made corresponding changes to the documentation.~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
