### PR TITLE
Fixes the empty state UI of the attachment and adds labels to the rows/columns fields in the table menu.

### DIFF
--- a/src/components/Editor/CustomExtensions/Video/VideoComponent.jsx
+++ b/src/components/Editor/CustomExtensions/Video/VideoComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import classNames from "classnames";
@@ -18,14 +18,26 @@ const VideoComponent = ({
 
   const [captionWidth, setCaptionWidth] = useState(vidwidth || 0);
 
+  const figureRef = useRef(null);
+
   const { view } = editor;
   let height = vidheight;
   let width = vidwidth;
   const caption = node?.content?.content[0]?.text || "";
 
+  const editorElement = figureRef.current?.closest(".neeto-editor");
+  const maxVideoWidth = editorElement?.offsetWidth - 50;
+
   const handleResize = (_event, _direction, ref) => {
     height = ref.offsetHeight;
     width = ref.offsetWidth;
+
+    if (width > maxVideoWidth) {
+      width = maxVideoWidth;
+      const aspectRatio = ref.offsetHeight / ref.offsetWidth;
+      height = width * aspectRatio;
+    }
+    setCaptionWidth(width);
     view.dispatch(
       view.state.tr.setNodeMarkup(
         getPos(),
@@ -45,7 +57,7 @@ const VideoComponent = ({
     <NodeViewWrapper
       className={`neeto-editor__image-wrapper neeto-editor__image--${align}`}
     >
-      <figure>
+      <figure ref={figureRef}>
         <Menu {...{ align, deleteNode, editor, updateAttributes }} />
         <Resizable
           lockAspectRatio

--- a/src/components/Editor/Menu/Bubble/TableOption.jsx
+++ b/src/components/Editor/Menu/Bubble/TableOption.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import { withEventTargetValue } from "neetocommons/utils";
 import { Check, Close } from "neetoicons";
-import { Button } from "neetoui";
+import { Button, Label } from "neetoui";
 import { useTranslation } from "react-i18next";
 
 const TableOption = ({ editor, handleClose }) => {
@@ -24,23 +24,33 @@ const TableOption = ({ editor, handleClose }) => {
 
   return (
     <div className="neeto-editor-bubble-menu__table">
-      <input
-        autoFocus
-        data-cy="neeto-editor-fixed-menu-table-option-input"
-        min="1"
-        placeholder={t("neetoEditor.placeholders.rows")}
-        type="number"
-        value={rows}
-        onChange={withEventTargetValue(setRows)}
-      />
-      <input
-        data-cy="neeto-editor-bubble-menu-table-option-input"
-        min="1"
-        placeholder={t("neetoEditor.placeholders.columns")}
-        type="number"
-        value={columns}
-        onChange={withEventTargetValue(setColumns)}
-      />
+      <div className="neeto-editor-bubble-menu__table__menu-item">
+        <Label className="neeto-editor-bubble-menu__table__input-label">
+          {t("neetoEditor.menu.rows")}
+        </Label>
+        <input
+          autoFocus
+          data-cy="neeto-editor-fixed-menu-table-option-input"
+          min="1"
+          placeholder={t("neetoEditor.placeholders.rows")}
+          type="number"
+          value={rows}
+          onChange={withEventTargetValue(setRows)}
+        />
+      </div>
+      <div className="neeto-editor-bubble-menu__table__menu-item">
+        <Label className="neeto-editor-bubble-menu__table__input-label">
+          {t("neetoEditor.menu.columns")}
+        </Label>
+        <input
+          data-cy="neeto-editor-bubble-menu-table-option-input"
+          min="1"
+          placeholder={t("neetoEditor.placeholders.columns")}
+          type="number"
+          value={columns}
+          onChange={withEventTargetValue(setColumns)}
+        />
+      </div>
       <div className="neeto-editor-bubble-menu__table__buttons">
         <Button
           data-cy="neeto-editor-bubble-menu-table-option-create-button"

--- a/src/components/Editor/Menu/Fixed/components/TableOption.jsx
+++ b/src/components/Editor/Menu/Fixed/components/TableOption.jsx
@@ -65,6 +65,7 @@ const TableOption = ({
         <Input
           autoFocus
           data-cy="neeto-editor-fixed-menu-table-option-input"
+          label={t("neetoEditor.menu.rows")}
           min="1"
           placeholder={t("neetoEditor.placeholders.rows")}
           size="small"
@@ -74,6 +75,7 @@ const TableOption = ({
         />
         <Input
           data-cy="neeto-editor-fixed-menu-table-option-input"
+          label={t("neetoEditor.menu.columns")}
           min="1"
           placeholder={t("neetoEditor.placeholders.rows")}
           size="small"
@@ -81,12 +83,15 @@ const TableOption = ({
           value={columns}
           onChange={withEventTargetValue(setColumns)}
         />
-        <Button
-          data-cy="neeto-editor-fixed-menu-table-option-create-button"
-          label={t("neetoEditor.common.create")}
-          size="small"
-          onClick={handleSubmit}
-        />
+        <div className="neeto-editor-table-menu__button">
+          <Button
+            className="mt-auto"
+            data-cy="neeto-editor-fixed-menu-table-option-create-button"
+            label={t("neetoEditor.common.create")}
+            size="small"
+            onClick={handleSubmit}
+          />
+        </div>
       </Menu>
     </Dropdown>
   );

--- a/src/styles/editor/editor-content.scss
+++ b/src/styles/editor/editor-content.scss
@@ -305,6 +305,7 @@
       border: 2px solid rgb(var(--neeto-ui-gray-300));
       border-radius: var(--neeto-ui-rounded-lg);
       padding: 4px;
+      min-height: 52px;
     }
 
     img {

--- a/src/styles/editor/menu.scss
+++ b/src/styles/editor/menu.scss
@@ -301,7 +301,7 @@
 
     &__buttons {
       display: flex;
-      align-items: center;
+      align-self: flex-end;
       justify-content: space-between;
       gap: 4px;
     }
@@ -346,10 +346,28 @@
       }
     }
   }
+
+  &__table {
+    &__menu-item {
+      display: flex;
+      flex-direction: column;
+      gap: 4px
+    }
+    &__input-label {
+      color: white;
+    }
+  }
 }
 
 .neeto-editor-bubble-menu-animate-shake {
   animation: 1s linear infinite alternate both shake;
+}
+
+.neeto-editor-table-menu {
+  &__button {
+    display: flex;
+    align-items: flex-end;
+  }
 }
 
 .neeto-editor__image-menu {

--- a/src/styles/editor/menu.scss
+++ b/src/styles/editor/menu.scss
@@ -293,10 +293,20 @@
       line-height: 20px;
       width: 60px;
       height: 24px;
+      padding: 3px 5px;
 
       &::placeholder {
         color: rgba(var(--neeto-ui-white, 0.4));
       }
+    }
+
+    &__menu-item {
+      display: flex;
+      flex-direction: column;
+      gap: 4px
+    }
+    &__input-label {
+      color: white;
     }
 
     &__buttons {
@@ -344,17 +354,6 @@
         border-bottom-left-radius: var(--neeto-ui-rounded);
         border-bottom-right-radius: var(--neeto-ui-rounded);
       }
-    }
-  }
-
-  &__table {
-    &__menu-item {
-      display: flex;
-      flex-direction: column;
-      gap: 4px
-    }
-    &__input-label {
-      color: white;
     }
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -106,7 +106,9 @@
       "pasteUnformatted": "Paste Unformatted",
       "pasteUnformattedDescription": "Paste by removing all styles.",
       "tableDescription": "Add a table.",
-      "noResults": "No results"
+      "noResults": "No results",
+      "rows": "Rows",
+      "columns": "Columns"
     },
     "placeholders": {
       "columns": "Enter columns",


### PR DESCRIPTION
- Fixes #1157 
- Fixes #1142 
- Fixes #1095

**Description**
- Fixes the UI of the empty state of the inline images and videos.
- Fixes the video dimension not auto corrected when overflows.
- Adds labels for rows/columns fields in the table menu.


**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
