### PR TITLE
Fixes editing the lists when there are images on top.

### DIFF
--- a/src/components/Editor/CustomExtensions/KeyboardShortcuts/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/KeyboardShortcuts/ExtensionConfig.js
@@ -1,4 +1,5 @@
 import { Extension } from "@tiptap/core";
+import { liftTarget } from "@tiptap/pm/transform";
 
 const KeyboardShortcuts = ({ onSubmit, shortcuts, isBlockQuoteActive }) =>
   Extension.create({
@@ -20,6 +21,40 @@ const KeyboardShortcuts = ({ onSubmit, shortcuts, isBlockQuoteActive }) =>
 
           return false;
         },
+        // To fix the issue with backspace on the empty list item moving the focus to the block on top.
+        // https://github.com/ueberdosis/tiptap/issues/2829#issuecomment-1511064298
+        Backspace: () =>
+          this.editor.commands.command(({ tr }) => {
+            const { selection, doc } = tr;
+            const { $cursor } = selection;
+            const depth = $cursor?.depth;
+
+            if (
+              $cursor &&
+              depth >= 3 && // At least the structure is doc -> orderedList/bulletList -> listItem -> paragraph
+              $cursor.parent.type.name === "paragraph" && // The cursor is inside a paragraph.
+              $cursor.parentOffset === 0 && // The cursor is at the beginning of the paragraph.
+              $cursor.node(depth - 1).type.name === "listItem" && // The paragraph is inside a listItem.
+              $cursor.index(depth - 1) === 0 && // The paragraph is at the beginning of the listItem.
+              $cursor.index(depth - 2) === 0 // The listItem is at the beginning of the list.
+            ) {
+              const listItemNode = $cursor.node(depth - 1);
+              const listItemPos = $cursor.before(depth - 1);
+              const $contentBegin = doc.resolve(listItemPos + 1);
+              const $contentEnd = doc.resolve(
+                listItemPos + listItemNode.nodeSize - 1
+              );
+              const range = $contentBegin.blockRange($contentEnd);
+              const target = liftTarget(range);
+              if (target !== null) {
+                tr.lift(range, target);
+
+                return true;
+              }
+            }
+
+            return false;
+          }),
         ...shortcuts,
       };
     },


### PR DESCRIPTION
- Fixes #1094

**Description**
Fixes the pressing backspace on the zeroth index of the list moving focus to the block on top.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x]  I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
