### PR TITLE
Fixes the flickering of the drop file UI and overlay stayin permanently when a drop is cancelled.

### DIFF
--- a/src/hooks/useDropFiles.js
+++ b/src/hooks/useDropFiles.js
@@ -3,11 +3,13 @@ import { useEffect } from "react";
 const useDropFiles = ({ dropTargetRef, attachments = [], onDrop }) => {
   useEffect(() => {
     const dropZone = dropTargetRef?.current;
-    let isDragging = false;
+    let isDragging = false,
+      timeout;
 
     const handleDragOver = event => {
       event.preventDefault();
       event.stopPropagation();
+      timeout && clearTimeout(timeout);
       if (!isDragging) {
         isDragging = true;
         dropZone.classList.add("is-dragging-over-files");
@@ -17,8 +19,11 @@ const useDropFiles = ({ dropTargetRef, attachments = [], onDrop }) => {
     const handleDragLeave = event => {
       event.preventDefault();
       event.stopPropagation();
-      if (!isDragging) {
-        dropZone.classList.remove("is-dragging-over-files");
+      if (isDragging) {
+        timeout = setTimeout(() => {
+          isDragging = false;
+          dropZone.classList.remove("is-dragging-over-files");
+        }, 0);
       }
     };
 
@@ -33,8 +38,8 @@ const useDropFiles = ({ dropTargetRef, attachments = [], onDrop }) => {
     };
 
     if (dropZone) {
-      dropZone.addEventListener("dragover", handleDragOver);
       dropZone.addEventListener("dragleave", handleDragLeave);
+      dropZone.addEventListener("dragover", handleDragOver);
       dropZone.addEventListener("drop", handleDrop);
     }
 


### PR DESCRIPTION
- Fixes #1193 

**Description**
- The events `dragenter`, `dragleave`, `dragover` are all firing multiple times.
- The only solution was to remove the drop UI asynchronously and cancel that if `dragover` or `dragenter` event is fired in between.

![drag-ui-fix](https://github.com/user-attachments/assets/f3d10d84-8e4a-405f-992f-73f7acc4c6c3)

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
