### PR TITLE
Fixes the renderHtml breaking when the image src is empty.

### DIFF
--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -82,6 +82,8 @@ export default Node.create({
   renderHTML({ node, HTMLAttributes }) {
     const { align, src, figheight, figwidth } = node.attrs;
 
+    if (!src) return ["span"];
+
     const openImageInNewTab = this.options.openImageInNewTab;
 
     const wrapperDivAttrs = {
@@ -103,24 +105,23 @@ export default Node.create({
 
     const captionAttrs = { style: `width:${figwidth}px;` };
 
-    let imageNode = [];
-    if (src) {
-      imageNode = [
-        "img",
-        mergeAttributes(HTMLAttributes, {
-          draggable: false,
-          contenteditable: false,
-        }),
-      ];
-    }
-
     return [
       "div",
       wrapperDivAttrs,
       [
         "figure",
         this.options.HTMLAttributes,
-        ["a", wrapperLinkAttrs, imageNode],
+        [
+          "a",
+          wrapperLinkAttrs,
+          [
+            "img",
+            mergeAttributes(HTMLAttributes, {
+              draggable: false,
+              contenteditable: false,
+            }),
+          ],
+        ],
         ["figcaption", captionAttrs, 0],
       ],
     ];


### PR DESCRIPTION
- Fixes #1226 

**Description**
- Fixes passing empty array to renderSpec crashing the application.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
