### PR TITLE
Adds highlight lines feature to the code block.

### DIFF
--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -94,7 +94,10 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
   };
 
   return (
-    <NodeViewWrapper data-cy="neeto-editor-code-block">
+    <NodeViewWrapper
+      className="ne-codeblock-nodeview-wrapper"
+      data-cy="neeto-editor-code-block"
+    >
       <div {...{ ref }}>
         <pre ref={handleContentMount}>
           <div

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -8,6 +8,7 @@ import { union } from "ramda";
 import { useTranslation } from "react-i18next";
 
 import { SORTED_LANGUAGE_LIST } from "./constants";
+import { codeBlockHighlightKey } from "./plugins";
 
 const { Menu, MenuItem } = Dropdown;
 
@@ -74,6 +75,8 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
     );
 
     editor.commands.updateAttributes(codeBlock.type, { highlightedLines });
+    // Trigger the plugin to update decorations
+    editor.view.dispatch(editor.state.tr.setMeta(codeBlockHighlightKey, true));
   };
 
   return (

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -143,6 +143,7 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
                 icon={Highlight}
                 size="small"
                 style="secondary"
+                tooltipProps={{ content: t("neetoEditor.menu.highlight") }}
                 onClick={handleHighlight}
               />
             )}

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -49,6 +49,10 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
     };
   }, [editor, handleSelectionChange]);
 
+  useEffect(() => {
+    editor.view.dispatch(editor.state.tr.setMeta(codeBlockHighlightKey, true));
+  }, []);
+
   const handleHighlight = () => {
     const { from, to } = editor.state.selection;
     const $from = editor.state.doc.resolve(from);

--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -33,6 +33,15 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
     }
   };
 
+  useEffect(() => {
+    editor.on("selectionUpdate", handleSelectionChange);
+
+    return () => {
+      editor.off("selectionUpdate", handleSelectionChange);
+    };
+  }, [editor, handleSelectionChange]);
+
+
   return (
     <NodeViewWrapper data-cy="neeto-editor-code-block">
       <div {...{ ref }}>
@@ -78,6 +87,13 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
               style="secondary"
               value={node?.content?.content[0]?.text}
             />
+            {showHighlightButton && (
+              <Button
+                label="Highlight"
+                size="small"
+                style="secondary"
+              />
+            )}
           </div>
           <NodeViewContent as="code" />
         </pre>

--- a/src/components/Editor/CustomExtensions/CodeBlock/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/CodeBlock/ExtensionConfig.js
@@ -3,8 +3,26 @@ import { ReactNodeViewRenderer } from "@tiptap/react";
 import { lowlight } from "lowlight";
 
 import CodeBlockComponent from "./CodeBlockComponent";
+import { codeBlockHighlightPlugin } from "./plugins";
 
 export default CodeBlockLowlight.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      highlightedLines: {
+        default: [],
+        parseHTML: element =>
+          element.dataset.highlightedLines?.split(",").map(Number) || [],
+        renderHTML: attributes => ({
+          "data-highlighted-lines":
+            attributes.highlightedLines?.join(",") ?? "",
+        }),
+      },
+    };
+  },
+  addProseMirrorPlugins() {
+    return [...(this.parent?.() || []), codeBlockHighlightPlugin];
+  },
   addNodeView() {
     return ReactNodeViewRenderer(CodeBlockComponent);
   },

--- a/src/components/Editor/CustomExtensions/CodeBlock/plugins.js
+++ b/src/components/Editor/CustomExtensions/CodeBlock/plugins.js
@@ -1,0 +1,73 @@
+/* eslint-disable @bigbinary/neeto/file-name-and-export-name-standards */
+import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+const codeBlockHighlightKey = new PluginKey("codeBlockHighlight");
+
+function createLineDecoration(from, lineNumber) {
+  return Decoration.widget(from, view => {
+    const line = document.createElement("div");
+    line.className = "highlighted-line";
+    line.setAttribute("data-line-number", lineNumber.toString());
+
+    // Set the height of the highlight to match the line height
+    const lineElement = view.domAtPos(from).node;
+    if (lineElement) {
+      const lineHeight = window.getComputedStyle(lineElement).lineHeight;
+      line.style.height = lineHeight;
+    }
+
+    return line;
+  });
+}
+
+function getLineRanges(node, pos) {
+  const lines = node.textContent.split("\n");
+  let currentPos = pos + 1; // +1 to skip the opening tag of the code block
+
+  return lines.map((line, index) => {
+    const from = currentPos;
+    const to = from + line.length; // +1 for newline, except last line
+    currentPos = to + (index < lines.length - 1 ? 1 : 0);
+
+    return { from, to, lineNumber: index + 1 };
+  });
+}
+
+const codeBlockHighlightPlugin = new Plugin({
+  key: codeBlockHighlightKey,
+  state: {
+    init() {
+      return DecorationSet.empty;
+    },
+    apply(tr, set) {
+      set = set.map(tr.mapping, tr.doc);
+
+      if (tr.getMeta(codeBlockHighlightKey)) {
+        const decorations = [];
+        tr.doc.descendants((node, pos) => {
+          if (!(node.type.name === "codeBlock")) return;
+          const highlightedLines = node.attrs.highlightedLines || [];
+          const lineRanges = getLineRanges(node, pos);
+
+          lineRanges.forEach(({ from, lineNumber }) => {
+            if (highlightedLines.includes(lineNumber)) {
+              decorations.push(createLineDecoration(from, lineNumber));
+            }
+          });
+        });
+
+        return DecorationSet.create(tr.doc, decorations);
+      }
+
+      return set;
+    },
+  },
+  props: {
+    decorations(state) {
+      return this.getState(state);
+    },
+  },
+});
+
+export { codeBlockHighlightPlugin, codeBlockHighlightKey };

--- a/src/components/EditorContent/codeBlockHighlight.js
+++ b/src/components/EditorContent/codeBlockHighlight.js
@@ -1,7 +1,31 @@
+/* eslint-disable @bigbinary/neeto/file-name-and-export-name-standards */
 import hljs from "highlight.js/lib/common";
 
+const highlightLinesScriptCDNPath =
+  "//cdn.jsdelivr.net/gh/TRSasasusu/highlightjs-highlight-lines.js@1.2.0/highlightjs-highlight-lines.min.js";
+
+function applyLineHighlighting(codeElement) {
+  hljs.highlightElement(codeElement);
+  const preElement = codeElement.closest("pre");
+
+  const highlightedLines = preElement.getAttribute("data-highlighted-lines");
+  if (highlightedLines) {
+    const linesToHighlight = highlightedLines.split(",").map(Number);
+    const highlightLinesOptions = linesToHighlight.map(line => ({
+      start: line,
+      end: line,
+      color: "rgba(255, 255, 0, 0.2)",
+    }));
+    hljs.highlightLinesElement(codeElement, highlightLinesOptions);
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
-  document
-    .querySelectorAll("pre code")
-    .forEach(element => hljs.highlightElement(element));
+  const script = document.createElement("script");
+  script.src = highlightLinesScriptCDNPath;
+  script.async = true;
+  document.head.appendChild(script);
+  script.addEventListener("load", () => {
+    document.querySelectorAll("pre code").forEach(applyLineHighlighting);
+  });
 });

--- a/src/components/EditorContent/codeBlockHighlight.js
+++ b/src/components/EditorContent/codeBlockHighlight.js
@@ -11,11 +11,13 @@ function applyLineHighlighting(codeElement) {
   const highlightedLines = preElement.getAttribute("data-highlighted-lines");
   if (highlightedLines) {
     const linesToHighlight = highlightedLines.split(",").map(Number);
-    const highlightLinesOptions = linesToHighlight.map(line => ({
-      start: line,
-      end: line,
-      color: "rgba(255, 255, 0, 0.2)",
-    }));
+    const highlightLinesOptions = linesToHighlight
+      .filter(line => line > 0)
+      .map(line => ({
+        start: line,
+        end: line,
+        color: "rgba(255, 255, 0, 0.2)",
+      }));
     hljs.highlightLinesElement(codeElement, highlightLinesOptions);
   }
 }

--- a/src/components/EditorContent/constants.js
+++ b/src/components/EditorContent/constants.js
@@ -8,7 +8,7 @@ export const SANITIZE_OPTIONS = {
 };
 
 export const CODE_BLOCK_REGEX =
-  /<pre><code(?:\s+class="language-([^"]*)")?>([\S\s]*?)<\/code><\/pre>/gim;
+  /<pre(?:\s+[^>]+)?><code(?:\s+class="language-([^"]*)")?>([\S\s]*?)<\/code><\/pre>/gim;
 
 export const VARIABLE_SPAN_REGEX =
   /<span data-variable="" [^>]*data-label="([^"]+)">{{([^}]+)}}<\/span>/g;

--- a/src/components/EditorContent/index.jsx
+++ b/src/components/EditorContent/index.jsx
@@ -10,7 +10,11 @@ import "src/styles/editor/editor-content.scss";
 
 import { EDITOR_CONTENT_CLASSNAME, SANITIZE_OPTIONS } from "./constants";
 import ImagePreview from "./ImagePreview";
-import { highlightCode, substituteVariables } from "./utils";
+import {
+  highlightCode,
+  substituteVariables,
+  applyLineHighlighting,
+} from "./utils";
 
 const EditorContent = ({
   content = "",
@@ -65,6 +69,7 @@ const EditorContent = ({
   useEffect(() => {
     injectCopyButtonToCodeBlocks();
     bindImageClickListener();
+    applyLineHighlighting(editorContentRef.current);
   }, [content]);
 
   return (

--- a/src/components/EditorContent/utils.js
+++ b/src/components/EditorContent/utils.js
@@ -27,43 +27,39 @@ const buildReactElementFromAST = element => {
   return element.value;
 };
 
-function highlightLinesCode(code, options) {
-  function highlightLinesCodeWithoutNumbers() {
-    code.innerHTML = code.innerHTML.replace(
-      /([ \S]*\n|[ \S]*$)/gm,
-      match => `<div class="highlight-line">${match}</div>`
-    );
+const highlightLinesCode = (code, options) => {
+  code.innerHTML = code.innerHTML.replace(
+    /([ \S]*\n|[ \S]*$)/gm,
+    match => `<div class="highlight-line">${match}</div>`
+  );
 
-    if (options === undefined) {
-      return;
-    }
-
-    const paddingLeft = parseInt(window.getComputedStyle(code).paddingLeft);
-    const paddingRight = parseInt(window.getComputedStyle(code).paddingRight);
-
-    const lines = code.getElementsByClassName("highlight-line");
-    const scroll_width = code.scrollWidth;
-    // eslint-disable-next-line @bigbinary/neeto/use-array-methods
-    for (const option of options) {
-      for (let j = option.start; j <= option.end; ++j) {
-        lines[j].style.backgroundColor = option.color;
-        lines[j].style.minWidth = `${
-          scroll_width - paddingLeft - paddingRight
-        }px`;
-      }
-    }
+  if (options === undefined) {
+    return;
   }
 
-  highlightLinesCodeWithoutNumbers();
-}
+  const paddingLeft = parseInt(window.getComputedStyle(code).paddingLeft);
+  const paddingRight = parseInt(window.getComputedStyle(code).paddingRight);
 
-export const highlightLinesElement = (code, options, has_numbers) => {
+  const lines = code.getElementsByClassName("highlight-line");
+  const scroll_width = code.scrollWidth;
+  // eslint-disable-next-line @bigbinary/neeto/use-array-methods
+  for (const option of options) {
+    for (let j = option.start; j <= option.end; ++j) {
+      lines[j].style.backgroundColor = option.color;
+      lines[j].style.minWidth = `${
+        scroll_width - paddingLeft - paddingRight
+      }px`;
+    }
+  }
+};
+
+export const highlightLinesElement = (code, options) => {
   // eslint-disable-next-line @bigbinary/neeto/use-array-methods
   for (const option of options) {
     --option.start;
     --option.end;
   }
-  highlightLinesCode(code, options, has_numbers);
+  highlightLinesCode(code, options);
 };
 
 export const highlightCode = content => {

--- a/src/styles/editor/_codeblock.scss
+++ b/src/styles/editor/_codeblock.scss
@@ -1,0 +1,10 @@
+.ne-codeblock-nodeview-wrapper {
+  .highlighted-line {
+    background-color: rgba(255, 255, 0, 0.2);
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+}

--- a/src/styles/editor/editor-content.scss
+++ b/src/styles/editor/editor-content.scss
@@ -152,6 +152,24 @@
         margin: 4px 4px;
       }
     }
+
+    .highlight-line {
+      position: relative;
+      &:before {
+        left: -12px;
+      }
+      &:after {
+        right: -12px;
+      }
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        top: 0px;
+        width: 12px;
+        height: 25px;
+        background-color: inherit;
+      }
+    }
   }
 
   pre > code {

--- a/src/styles/editor/index.scss
+++ b/src/styles/editor/index.scss
@@ -7,6 +7,7 @@
 @import "./table";
 @import "./link-popover";
 @import "./collaboration-cursor";
+@import "./codeblock";
 
 .ProseMirror {
   overflow-y: auto;


### PR DESCRIPTION
Fixes #1220 

**Description**
- Adds feature to toggle line highlights in code block component.

EditorContent:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/94233ed5-99fa-4d05-b5e8-609dc7049be1">

Editor:
<img width="753" alt="image" src="https://github.com/user-attachments/assets/70df405c-57f2-4bfa-93aa-6bb98569a812">

codeBlockHighlight.js
<img width="745" alt="image" src="https://github.com/user-attachments/assets/bc77c950-98eb-425d-986e-868577bca6c1">


**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
