### PR TITLE
Fixes issues with the attachments preview.

### DIFF
--- a/src/hooks/utils/index.js
+++ b/src/hooks/utils/index.js
@@ -1,0 +1,2 @@
+export const getRandomString = () =>
+  Math.random().toString(36).substring(7).toUpperCase();


### PR DESCRIPTION
Fixes #1236 

**Description**
- Nests the files and the upload status under a context id so that different instances of `useFileUploader` hook stores files and status under a different key.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
