### PR TITLE
Adds category label to the variabe if the selected variable belongs to a category.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@
 .env.test.local
 .env.production.local
 
+# Ignore yalc generated files
+yalc.lock
+/.yalc
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/src/components/Editor/CustomExtensions/Variable/VariableComponent.jsx
+++ b/src/components/Editor/CustomExtensions/Variable/VariableComponent.jsx
@@ -1,4 +1,5 @@
 import { NodeViewWrapper } from "@tiptap/react";
+import { Tooltip } from "neetoui";
 
 import { MAX_VARIABLE_NAME_DISPLAY_LENGTH } from "./constants";
 
@@ -16,8 +17,10 @@ const VariableComponent = ({ node, extension }) => {
       data-variable=""
     >
       {extension.options.charOpen}
-      {variableName?.substr(0, MAX_VARIABLE_NAME_DISPLAY_LENGTH)?.trim()}
-      {shouldTruncate && "..."}
+      <Tooltip content={variableName} disabled={!shouldTruncate} position="top">
+        {variableName?.substr(0, MAX_VARIABLE_NAME_DISPLAY_LENGTH)?.trim()}
+        {shouldTruncate && "..."}
+      </Tooltip>
       {extension.options.charClose}
     </NodeViewWrapper>
   );

--- a/src/components/Editor/Menu/Fixed/index.jsx
+++ b/src/components/Editor/Menu/Fixed/index.jsx
@@ -140,9 +140,17 @@ const Fixed = ({
     options.includes(EDITOR_OPTIONS.VIDEO_UPLOAD);
 
   const handleVariableClick = item => {
-    const { category, key, label } = item;
+    const { category, categoryLabel, key, label } = item;
     const variableName = category ? `${category}.${key}` : key;
-    editor.chain().focus().setVariable({ id: variableName, label }).run();
+    const variableLabel = category
+      ? `${categoryLabel || category}:${label}`
+      : label;
+
+    editor
+      .chain()
+      .focus()
+      .setVariable({ id: variableName, label: variableLabel })
+      .run();
   };
 
   return (


### PR DESCRIPTION
Fixes #1240

**Description**
- Sets category label when available in the variable label separated by a colon symbol.
- NeetoMolecules is updated to include the category label in the onClick event. PR - https://github.com/bigbinary/neeto-molecules/pull/1695

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/894b0b80-e7c6-4228-bfd2-1dc6a6570dd7">

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
