### PR TITLE
Fixes wrong order in filtering out the empty values and numbers less than one.

### DIFF
--- a/src/components/Editor/CustomExtensions/CodeBlock/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/CodeBlock/ExtensionConfig.js
@@ -14,8 +14,8 @@ export default CodeBlockLowlight.extend({
         parseHTML: element =>
           element.dataset.highlightedLines
             ?.split(",")
-            .filter(Boolean)
-            .map(Number) || [],
+            .map(Number)
+            .filter(Boolean) || [],
         renderHTML: attributes => ({
           "data-highlighted-lines":
             attributes.highlightedLines?.join(",") ?? "",

--- a/src/components/EditorContent/utils/index.js
+++ b/src/components/EditorContent/utils/index.js
@@ -99,8 +99,8 @@ export const applyLineHighlighting = editorContent => {
     if (highlightedLines) {
       const linesToHighlight = highlightedLines
         .split(",")
-        ?.filter(Boolean)
-        .map(Number);
+        .map(Number)
+        .filter(Boolean);
 
       const highlightLinesOptions = linesToHighlight.map(line => ({
         start: line,


### PR DESCRIPTION
Fixes https://github.com/bigbinary/neeto-planner-web/issues/6838

**Description**
From storybook demo with the same content from the issue in planner.
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/362b7770-b548-4bfb-beff-9fc563e06437">

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
