### PR TITLE
Made the tables responsive

### DIFF
--- a/src/components/Editor/CustomExtensions/Table/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Table/ExtensionConfig.js
@@ -24,7 +24,11 @@ const Table = TiptapTable.extend({
       }
     );
 
-    return ["table", {}, ["colgroup", ...colgroups], ["tbody", 0]];
+    return [
+      "div",
+      { class: "table-responsive" },
+      ["table", {}, ["colgroup", ...colgroups], ["tbody", 0]],
+    ];
   },
 
   addKeyboardShortcuts() {

--- a/src/styles/editor/_table.scss
+++ b/src/styles/editor/_table.scss
@@ -1,9 +1,12 @@
 .neeto-editor-table {
-  display: relative;
+  position: relative;
   width: fit-content;
   margin: 8px 0 0;
+  max-width: 100%;
+  overflow-x: auto;
 
   table {
+
     th,
     td {
       p {
@@ -31,6 +34,8 @@
   &__wrapper {
     display: flex;
     gap: 2px;
+    max-width: 100%;
+    overflow-x: auto;
   }
 
   &__add-row,
@@ -50,7 +55,7 @@
       color: rgb(var(--neeto-ui-gray-500)) !important;
       font-size: var(--neeto-ui-text-base) !important;
       line-height: 16px !important;
-      font-weight: var(	--neeto-ui-font-light) !important;
+      font-weight: var(--neeto-ui-font-light) !important;
     }
 
     &:hover {
@@ -59,6 +64,7 @@
   }
 
   &:hover {
+
     .neeto-editor-table__add-row,
     .neeto-editor-table__add-column {
       visibility: visible;

--- a/src/styles/editor/editor-content.scss
+++ b/src/styles/editor/editor-content.scss
@@ -94,6 +94,11 @@
   word-break: break-word;
   tab-size: 2;
 
+  .table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
   // Sizing
   &--size-large {
     --neeto-editor-content-paragraph-font-size: 1.125rem;


### PR DESCRIPTION
Fixes #1258 

**Description**

https://praveen-murali.neetorecord.com/watch/4899684d-b7e7-4401-9068-2c334a05dfad

- Made the tables responsive.

## After

<img width="1440" alt="Screenshot 2024-11-05 at 9 19 46 PM" src="https://github.com/user-attachments/assets/8e8e34d3-85e3-4d24-886f-761adcc394db">

<img width="1440" alt="Screenshot 2024-11-05 at 9 19 22 PM" src="https://github.com/user-attachments/assets/53d550bc-3ebc-48f3-9294-6793b628f07b">

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
