### PR TITLE
Updates header links script to handle duplicate header texts.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -141,7 +141,7 @@ const config = args => {
       plugins,
     },
     {
-      input: "./src/components/EditorContent/navigableHeadings.js",
+      input: "./src/components/EditorContent/headerLinks.js",
       output: {
         dir: `${__dirname}/dist`,
         format: "cjs",

--- a/src/components/EditorContent/constants.js
+++ b/src/components/EditorContent/constants.js
@@ -16,5 +16,5 @@ export const VARIABLE_SPAN_REGEX =
 export const LANGUAGE_LIST = [...lowlight.listLanguages(), "html"];
 
 export const EDITOR_CONTENT_DEFAULT_CONFIGURATION = {
-  navigableHeader: false,
+  enableHeaderLinks: false,
 };

--- a/src/components/EditorContent/headerLinks.js
+++ b/src/components/EditorContent/headerLinks.js
@@ -1,7 +1,7 @@
-import { makeHeadingsNavigable } from "./utils/headers";
+import { buildHeaderLinks } from "./utils/headers";
 
 document.addEventListener("DOMContentLoaded", () => {
   const editorContent = document.querySelector(".neeto-editor-content");
 
-  if (editorContent) makeHeadingsNavigable(editorContent);
+  if (editorContent) buildHeaderLinks(editorContent);
 });

--- a/src/components/EditorContent/index.jsx
+++ b/src/components/EditorContent/index.jsx
@@ -20,7 +20,7 @@ import {
   applyLineHighlighting,
   applySyntaxHighlighting,
 } from "./utils";
-import { makeHeadingsNavigable } from "./utils/headers";
+import { buildHeaderLinks } from "./utils/headers";
 
 const EditorContent = ({
   content = "",
@@ -81,8 +81,8 @@ const EditorContent = ({
     injectCopyButtonToCodeBlocks();
     bindImageClickListener();
     applyLineHighlighting(editorContentRef.current);
-    configuration.navigableHeader &&
-      makeHeadingsNavigable(editorContentRef.current);
+    configuration.enableHeaderLinks &&
+      buildHeaderLinks(editorContentRef.current);
   }, [content]);
 
   return (

--- a/src/components/EditorContent/utils/headers.js
+++ b/src/components/EditorContent/utils/headers.js
@@ -28,13 +28,20 @@ const convertTextToId = text =>
     .replace(/[^a-z0-9\s]/g, "")
     .replace(/\s+/g, "-");
 
-export const makeHeadingsNavigable = editorContentNode => {
+export const buildHeaderLinks = editorContentNode => {
   const headerTags = editorContentNode.querySelectorAll(
     "h1, h2, h3, h4, h5, h6"
   );
+  const usedIds = new Map();
 
   headerTags.forEach(heading => {
-    const headingId = convertTextToId(heading.textContent);
+    let headingId = convertTextToId(heading.textContent);
+    if (usedIds.has(headingId)) {
+      const count = usedIds.get(headingId);
+      usedIds.set(headingId, count + 1);
+      headingId = `${headingId}-${count}`;
+    } else usedIds.set(headingId, 1);
+
     heading.setAttribute("id", headingId);
 
     const anchor = document.createElement("a");

--- a/stories/Walkthroughs/Output/EditorContentDemo.jsx
+++ b/stories/Walkthroughs/Output/EditorContentDemo.jsx
@@ -19,7 +19,7 @@ const EditorContentDemo = () => {
         <EditorContent
           {...{ content }}
           className="neeto-ui-p-4"
-          configuration={{ navigableHeader: true }}
+          configuration={{ enableHeaderLinks: true }}
         />
       </div>
       <div>

--- a/stories/constants.js
+++ b/stories/constants.js
@@ -42,8 +42,8 @@ export const EDITOR_CONTENT_PROP_TABLE_ROWS = [
   ],
   [
     "configuration",
-    "Accepts an object, navigableHeader can be set to true or false in the configuration, default value is false.",
-    `{navigableHeader: true}`,
+    "Accepts an object, enableHeaderLinks can be set to true or false in the configuration, default value is false.",
+    `{enableHeaderLinks: true}`,
   ],
 ];
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -150,7 +150,7 @@ interface AttachmentsProps {
 }
 
 type EditorContentConfigType = {
-  navigableHeader?: boolean;
+  enableHeaderLinks?: boolean;
 }
 
 export function Editor(props: EditorProps): JSX.Element;


### PR DESCRIPTION
Fixes #1262 

**Description**
- Updated header links script to handle duplicate header texts and append an index to make it unique.
- Renamed navigableHeadings to headerLinks since that name is better and have the same name in NeetoKB.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
