### PR TITLE
Added border to image

### DIFF
--- a/src/styles/editor/editor-content.scss
+++ b/src/styles/editor/editor-content.scss
@@ -87,6 +87,8 @@
   --neeto-editor-content-blockquote-border-left-width: 4px;
   --neeto-editor-content-blockquote-margin-bottom: 1rem;
   --neeto-editor-content-blockquote-padding-left: 0.75rem;
+  --neeto-editor-content-image-border-color: 228, 228, 231;
+  --neeto-editor-content-image-border-radius: 8px;
 }
 
 .neeto-editor-content {
@@ -561,6 +563,10 @@
 
     img {
       cursor: zoom-in;
+      border-style: solid;
+      border-width: 1px;
+      border-color: rgba(var(--neeto-editor-content-image-border-color));
+      border-radius: var(--neeto-editor-content-image-border-radius);
     }
   }
 


### PR DESCRIPTION
Fixes #1299 

**Description**

- Added a light gray border around the image.

<img width="1440" alt="Screenshot 2025-01-13 at 5 31 57 PM" src="https://github.com/user-attachments/assets/c4ba8d8a-de87-41db-8787-277289fa9f5a" />


**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
