### PR TITLE
Add default spacing at the bottom of the Table

### DIFF
--- a/src/styles/editor/_table.scss
+++ b/src/styles/editor/_table.scss
@@ -1,7 +1,7 @@
 .neeto-editor-table {
   position: relative;
   width: fit-content;
-  margin: 8px 0 0;
+  margin: 1rem 0 0;
   max-width: 100%;
   overflow-x: auto;
 

--- a/src/styles/editor/editor-content.scss
+++ b/src/styles/editor/editor-content.scss
@@ -103,6 +103,7 @@
   .table-responsive {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    margin: 1rem 0;
   }
 
   // Sizing

--- a/stories/Walkthroughs/Output/EditorContentDemo.stories.mdx
+++ b/stories/Walkthroughs/Output/EditorContentDemo.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs";
+import { Meta, Unstyled } from "@storybook/addon-docs";
 import {
   EDITOR_PROP_TABLE_COLUMNS,
   EDITOR_CONTENT_PROP_TABLE_ROWS,
@@ -22,6 +22,9 @@ import EditorContentDemo from "./EditorContentDemo";
 
 # EditorContent demo
 
-To update the preview content, make use of the editor below. The changes will be instantly updated in the preview.
+To update the preview content, make use of the editor below. The changes will be
+instantly updated in the preview.
 
-<EditorContentDemo />
+<Unstyled>
+  <EditorContentDemo />
+</Unstyled>


### PR DESCRIPTION
- Fixes #1301 
- Fixes #1302 

**Description**

- Added default bottom spacing to the table for better layout consistency.
- Resolved the issue of Storybook's default styles interfering with React component styles within the preview.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _A

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
