### PR TITLE
Serve NeetEditor assets through Cloudfront

### DIFF
--- a/.github/workflows/create_and_publish_releases.yml
+++ b/.github/workflows/create_and_publish_releases.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup NodeJS LTS version
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Setup the project
         run: yarn install
@@ -79,3 +79,14 @@ jobs:
         with:
           access: "public"
           token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload public assets to CDN
+        run: |
+          yarn upload

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,3 +28,14 @@ jobs:
           access: "public"
           token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ github.event.release.prerelease && 'beta' || 'latest' }}
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload public assets to CDN
+        if: ${{ !github.event.release.prerelease }}
+        run: yarn upload

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@bigbinary/neeto-icons": "1.19.2",
     "@bigbinary/neeto-molecules": "3.3.13",
     "@bigbinary/neetoui": "7.0.1",
+    "@bigbinary/s3-uploader": "https://github.com/bigbinary/s3-uploader",
     "@faker-js/faker": "8.2.0",
     "@hocuspocus/provider": "^2.13.5",
     "@honeybadger-io/js": "6.5.3",
@@ -242,7 +243,8 @@
     "bundle": "NODE_ENV=production rollup --bundleConfigAsCjs -c rollup.config.js",
     "prepare": "husky install",
     "serve": "node .storybook/express",
-    "storybook": "storybook dev -p 6006"
+    "storybook": "storybook dev -p 6006",
+    "upload": "node scripts/publish"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json}": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.44.0-beta.0",
+  "version": "1.44.37",
   "types": "./types.d.ts",
   "description": "neetoEditor is the library that drives the rich text experience in all neeto products built at BigBinary",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.43.36",
+  "version": "1.44.0-beta.0",
   "types": "./types.d.ts",
   "description": "neetoEditor is the library that drives the rich text experience in all neeto products built at BigBinary",
   "keywords": [

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,35 @@
+const Uploader = require("@bigbinary/s3-uploader");
+const dotEnv = require("dotenv");
+
+dotEnv.config({ path: ".env" });
+
+const getS3UploaderConfig = () => ({
+  bucket: "neeto-editor-production",
+  destination: "neeto-editor",
+  distribution: "TODO",
+  distributionPath: "/neeto-editor*",
+  fileProperties: {
+    "*": { CacheControl: "no-cache" },
+  },
+});
+
+const uploadFiles = async () => {
+  const uploaderConfig = getS3UploaderConfig();
+  const uploader = new Uploader(uploaderConfig);
+
+  uploader.addFile("dist/editor-content.min.css");
+  uploader.addFile("dist/editor-output-pdf-email.css");
+  uploader.addFile("dist/codeblockHighlight.js");
+  uploader.addFile("dist/headerLinks.js");
+  uploader.addFile("dist/editorUtils.js");
+
+  try {
+    console.log("Starting upload...");
+    await uploader.upload();
+    console.log("Upload completed successfully.");
+  } catch (error) {
+    console.error("Upload failed:", error);
+  }
+};
+
+uploadFiles();

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -5,9 +5,7 @@ dotEnv.config({ path: ".env" });
 
 const getS3UploaderConfig = () => ({
   bucket: "neeto-editor-production",
-  destination: "neeto-editor",
-  distribution: "TODO",
-  distributionPath: "/neeto-editor*",
+  distribution: "E3IFTI8KVD6OKE",
   fileProperties: {
     "*": { CacheControl: "no-cache" },
   },

--- a/stories/Walkthroughs/Output/Output.stories.mdx
+++ b/stories/Walkthroughs/Output/Output.stories.mdx
@@ -78,7 +78,7 @@ Add the following line to the `<head></head>` tag of your HTML file.
 
 ```html
 <link
-  href="TODO"
+  href="https://neeto-editor-cdn.neeto.com/editor-content.min.css"
   rel="stylesheet"
 />
 ```
@@ -89,7 +89,7 @@ Add the following line to your .erb file. We have added extra CSS to fix a few i
 PDF generation plugins of Ruby on Rails.
 
 ```erb
-<%= stylesheet_link_tag "TODO", media: "all" %>
+<%= stylesheet_link_tag "https://neeto-editor-cdn.neeto.com/editor-output-pdf-email.css", media: "all" %>
 ```
 
 Use the above CDN link to include the styles in your project. Add the class
@@ -108,7 +108,7 @@ file.
 <script
   defer
   type="text/javascript"
-  src="TODO"
+  src="https://neeto-editor-cdn.neeto.com/codeblockHighlight.js"
 ></script>
 ```
 
@@ -125,7 +125,7 @@ Add the following lines to the SSG/SSR pages. The pages need not be converted to
 
 ```js
 <Script
-  src="TODO"
+  src="https://neeto-editor-cdn.neeto.com/headerLinks.js"
   strategy="afterInteractive"
 />
 ```
@@ -143,7 +143,7 @@ Add the following lines to the SSG/SSR pages. The pages need not be converted to
 
 ```js
 <Script
-  src="TODO"
+  src="https://neeto-editor-cdn.neeto.com/editorUtils.js"
   strategy="afterInteractive"
 />
 ```

--- a/stories/Walkthroughs/Output/Output.stories.mdx
+++ b/stories/Walkthroughs/Output/Output.stories.mdx
@@ -78,7 +78,7 @@ Add the following line to the `<head></head>` tag of your HTML file.
 
 ```html
 <link
-  href="https://cdn.jsdelivr.net/npm/@bigbinary/neeto-editor/dist/editor-content.min.css"
+  href="TODO"
   rel="stylesheet"
 />
 ```
@@ -89,7 +89,7 @@ Add the following line to your .erb file. We have added extra CSS to fix a few i
 PDF generation plugins of Ruby on Rails.
 
 ```erb
-<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@bigbinary/neeto-editor/dist/editor-output-pdf-email.css", media: "all" %>
+<%= stylesheet_link_tag "TODO", media: "all" %>
 ```
 
 Use the above CDN link to include the styles in your project. Add the class
@@ -108,7 +108,7 @@ file.
 <script
   defer
   type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/@bigbinary/neeto-editor/dist/codeBlockHighlight.js"
+  src="TODO"
 ></script>
 ```
 
@@ -125,7 +125,7 @@ Add the following lines to the SSG/SSR pages. The pages need not be converted to
 
 ```js
 <Script
-  src="https://cdn.jsdelivr.net/npm/@bigbinary/neeto-editor/dist/codeBlockHighlight.js"
+  src="TODO"
   strategy="afterInteractive"
 />
 ```
@@ -143,7 +143,7 @@ Add the following lines to the SSG/SSR pages. The pages need not be converted to
 
 ```js
 <Script
-  src="https://cdn.jsdelivr.net/npm/@bigbinary/neeto-editor/dist/editorUtils.js"
+  src="TODO"
   strategy="afterInteractive"
 />
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,6 +1549,15 @@
   resolved "https://registry.yarnpkg.com/@bigbinary/neetoui/-/neetoui-7.0.1.tgz#6994d8603fc68d56e5a5ea19011e8497a21bd4f6"
   integrity sha512-eoItgcJ5ocjUsE6hQdxh59BInvpiDJ2HSnFRPOym8aJbz8pyCY1VhtscQ3ESi0OE4MqyBhjNgYGWsXYpgrZA1A==
 
+"@bigbinary/s3-uploader@https://github.com/bigbinary/s3-uploader":
+  version "2.0.2"
+  resolved "https://github.com/bigbinary/s3-uploader#4d325da735af7a3f5a05ccc30104da16d152e3df"
+  dependencies:
+    aws-sdk "^2.1261.0"
+    glob "^8.0.3"
+    mime-types "^2.1.35"
+    minimatch "^5.1.0"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -5424,6 +5433,22 @@ avvvatars-react@0.4.2:
   dependencies:
     goober "^2.1.8"
 
+aws-sdk@^2.1261.0:
+  version "2.1692.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1692.0.tgz#9dac5f7bfcc5ab45825cc8591b12753aa7d2902c"
+  integrity sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.6.2"
+
 axios@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.0.tgz#f1e5292f26b2fd5c2e66876adc5b06cdbd7d2102"
@@ -5699,7 +5724,7 @@ base64-arraybuffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
-base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -5871,6 +5896,15 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -7816,6 +7850,11 @@ eventemitter3@^5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
+
 events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -8844,7 +8883,12 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ieee754@^1.1.13:
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -9363,15 +9407,15 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
+isarray@^1.0.0, isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -9493,6 +9537,11 @@ jiti@^1.18.2, jiti@^1.19.1:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
   integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 js-logger@1.6.1:
   version "1.6.1"
@@ -10596,7 +10645,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.34, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.34, mime-types@^2.1.35, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -10645,7 +10694,7 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatc
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -12563,6 +12612,11 @@ punycode.js@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
   integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -12624,6 +12678,11 @@ query-string@^7.1.0:
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -14087,6 +14146,16 @@ sass@1.69.5:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
+
+sax@>=0.6.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
@@ -15496,6 +15565,14 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.3.tgz#6f495f4b935de40ce4a0a52faee8954244f3d3ad"
@@ -15578,6 +15655,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 uuid@^8.3.2:
   version "8.3.2"
@@ -16100,6 +16182,19 @@ ws@^8.2.3, ws@^8.4.2:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
   integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
+
+xml2js@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
- Fixes #1268

**Description**

- Use `@bigbinary/s3-upoloader` to push public NeetoEditor assets to `neeto-editor-production` bucket.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
minor _t

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->


---

> [!NOTE]  
> 1. Create a `neeto-editor-production` bucket.
> 2. Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables in `neeto-editor` repository environment variables.
> 2. Serve the assets from the bucket through Cloudfront CDN.
> 3. The CDN URL should have the domain set to `https://cdn.neeto-editor.neeto.com`.
> 4. Update documentation with the new links.