### PR TITLE
If the current node and previous node are incompatable in a list, delete the current node

### DIFF
--- a/src/components/Editor/CustomExtensions/BulletList/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/BulletList/ExtensionConfig.js
@@ -45,7 +45,13 @@ export default BulletList.extend({
             return commands.deleteCurrentNode();
           }
 
-          return commands.joinBackward();
+          // Check if the current node and previous node are compatible for join
+          const prevListItem = $from.node($from.depth - 2);
+          if (prevListItem && isListNode(prevListItem)) {
+            return commands.joinBackward();
+          }
+
+          return commands.deleteCurrentNode();
         }),
     };
   },


### PR DESCRIPTION
- Fixes #https://github.com/bigbinary/neeto-editor/issues/1314#issuecomment-2634629708

**Description**

- If the current node and previous node are incompatable in a list, delete the current node.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
