### PR TITLE
Prioritize pasting text/plain if both text/plain and text/image are copied into the clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.45.8-beta.0",
+  "version": "1.45.8-beta.1",
   "types": "./types.d.ts",
   "description": "neetoEditor is the library that drives the rich text experience in all neeto products built at BigBinary",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbinary/neeto-editor",
-  "version": "1.45.7",
+  "version": "1.45.8-beta.0",
   "types": "./types.d.ts",
   "description": "neetoEditor is the library that drives the rich text experience in all neeto products built at BigBinary",
   "keywords": [

--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -182,6 +182,14 @@ export default Node.create({
                   $anchor: { pos },
                 },
               } = view.state;
+
+              // Microsoft Excel and a few other products might copy content as
+              // both `text/plain` and `text/html`. If `text/plain` exists,
+              // an early return will ensure that it fallbacks to tiptap's
+              // default paste behavior.
+              const text = event?.clipboardData?.getData("text/plain");
+              if (text) return;
+
               const hasFiles = event.clipboardData?.files?.length;
 
               if (!hasFiles) return;

--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -193,7 +193,11 @@ export default Node.create({
               if (!hasFiles) return;
 
               if (hasFiles && text) {
-                view.pasteText(text);
+                event.preventDefault();
+                const plainText =
+                  new DOMParser().parseFromString(text, "text/html").body
+                    .textContent ?? "";
+                view.pasteText(plainText);
 
                 return;
               }

--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -188,11 +188,15 @@ export default Node.create({
               // an early return will ensure that it fallbacks to tiptap's
               // default paste behavior.
               const text = event?.clipboardData?.getData("text/plain");
-              if (text) return;
-
               const hasFiles = event.clipboardData?.files?.length;
 
               if (!hasFiles) return;
+
+              if (hasFiles && text) {
+                view.pasteText(text);
+
+                return;
+              }
 
               const images = Array.from(event.clipboardData.files).filter(
                 file => /image/i.test(file.type)


### PR DESCRIPTION
- Fixes #1305 

**Description**

- Microsoft Excel and a few other products might copy content as both `text/plain` and `text/html`. If `text/plain` exists, an early return will ensure that it fallbacks to tiptap's default paste behavior.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->


https://abhay-ashokan.neetorecord.com/watch/5a0610a7f7c3583930a6