### PR TITLE
Added a transform rule to not convert <br/> tags to paragraph tags

### DIFF
--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -24,6 +24,7 @@ import {
   getEditorStyles,
   clipboardTextParser,
   setInitialPosition,
+  transformPastedHTML,
 } from "./utils";
 
 import Attachments from "../Attachments";
@@ -162,6 +163,7 @@ const Editor = (
         ...contentAttributes,
       },
       clipboardTextParser,
+      transformPastedHTML,
     },
     parseOptions: { preserveWhitespace: true },
     onCreate: ({ editor }) => !autoFocus && setInitialPosition(editor),

--- a/src/components/Editor/utils.js
+++ b/src/components/Editor/utils.js
@@ -72,3 +72,6 @@ export const transformEditorContent = content =>
 
 export const isEmojiSuggestionsMenuActive = () =>
   !!document.querySelector(".neeto-editor-emoji-suggestion");
+
+export const transformPastedHTML = content =>
+  content.replaceAll("<br />", "<p></p>");


### PR DESCRIPTION
- Fixes #1308 

- Added a custom `transformPastedHTML` rule to convert `<br />` tags to `<p></p>` tags. The default behavior of TipTap is to convert `<br />` tags to `<p><br /></p>` tags causing a duplicate new line in the pasted content.

@AbhayVAshokan _a patch _t