### PR TITLE
Fix codeblock button visibility issues

### DIFF
--- a/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
+++ b/src/components/Editor/CustomExtensions/CodeBlock/CodeBlockComponent.jsx
@@ -107,7 +107,7 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
             <Dropdown
               appendTo={() => document.body}
               buttonSize="small"
-              buttonStyle="secondary"
+              buttonStyle="tertiary"
               icon={Down}
               label={node.attrs?.language || t("neetoEditor.common.auto")}
               strategy="fixed"
@@ -138,14 +138,14 @@ const CodeBlockComponent = ({ node, editor, updateAttributes }) => {
             </Dropdown>
             <CopyToClipboardButton
               size="small"
-              style="secondary"
+              style="tertiary"
               value={node?.content?.content[0]?.text}
             />
             {showHighlightButton && (
               <Button
                 icon={Highlight}
                 size="small"
-                style="secondary"
+                style="tertiary"
                 tooltipProps={{ content: t("neetoEditor.menu.highlight") }}
                 onClick={handleHighlight}
               />

--- a/src/components/EditorContent/index.jsx
+++ b/src/components/EditorContent/index.jsx
@@ -51,7 +51,7 @@ const EditorContent = ({
       root.render(
         <CopyToClipboardButton
           size="small"
-          style="text"
+          style="tertiary"
           value={preTag.textContent}
         />
       );


### PR DESCRIPTION
- Fixes #1331 

**Description**

- Fixed the button visibility issues in the codeblock component.

### After
<img width="463" alt="Screenshot 2025-02-25 at 2 35 22 PM" src="https://github.com/user-attachments/assets/401399a9-98a9-4a1f-91dd-36a41f81fd7c" />

### Before
<img width="502" alt="Screenshot 2025-02-25 at 2 35 40 PM" src="https://github.com/user-attachments/assets/050ebb88-8aa8-44d8-9956-74638bdc50a5" />

---

- Updated codeblock button styles to `tertiary` for more visibility.

### After
<img width="481" alt="Screenshot 2025-02-25 at 2 29 56 PM" src="https://github.com/user-attachments/assets/0521db5c-b167-4b42-8441-5147f34253db" />

### Before
<img width="449" alt="Screenshot 2025-02-25 at 2 28 23 PM" src="https://github.com/user-attachments/assets/5a997a78-93cc-418b-a10a-a475dedb7eed" />



**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _A

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
