### PR TITLE
Updated the URL validation regex to have maximum TLD length of 63 characters

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -38,7 +38,7 @@ export const UNSPLASH_BASE_URL = "https://api.unsplash.com/search/photos";
 export const DIRECT_UPLOAD_ENDPOINT = "/api/direct_uploads";
 
 export const URL_REGEXP =
-  /[(http(s)?)://(www.)?a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
+  /[(http(s)?)://(www.)?a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
 
 export const YOUTUBE_URL_REGEXP =
   /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S*?)(\?[^#]*)?$/;


### PR DESCRIPTION
- Fixes #1334

**Description**

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->

patch _t
@AbhayVAshokan _a Please review
ICANN allows TLD to have a max length of 63 characters. 
[Reference](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_domain_name#:~:text=TLDs%20can%20contain%20special%20as%20well%20as%20latin%20characters.%20A%20TLD%27s%20maximum%20length%20is%2063%20characters)