### PR TITLE
Skips `onChange` calls in `onBlur` if there are no leading or trailing whitespace

### DIFF
--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -110,9 +110,10 @@ const Editor = (
 
   const handleBlur = props => {
     const { editor } = props;
-    const trimmedContent = removeEmptyTags(editor.getHTML());
+    const content = editor.getHTML();
+    const trimmedContent = removeEmptyTags(content);
 
-    onChange(trimmedContent);
+    if (content !== trimmedContent) onChange(trimmedContent);
     onBlur(props);
   };
 


### PR DESCRIPTION
- Fixes #1349 

**Description**
 - Skips `onChange` calls in `onBlur` if there are no leading or trailing whitespace

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@AbhayVAshokan _a Please review.

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
