### PR TITLE
Define a custom Italics extension to override the underscore mark in the inputRules

### DIFF
--- a/src/components/Editor/CustomExtensions/Italic/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Italic/ExtensionConfig.js
@@ -1,0 +1,7 @@
+import Italic from "@tiptap/extension-italic";
+
+export default Italic.extend({
+  addInputRules() {
+    return [];
+  },
+});

--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -27,6 +27,7 @@ import EmojiPicker from "../Emoji/EmojiPicker/ExtensionConfig";
 import EmojiSuggestion from "../Emoji/EmojiSuggestion/ExtensionConfig";
 import ImageExtension from "../Image/ExtensionConfig";
 import FigCaption from "../Image/FigCaption";
+import Italic from "../Italic/ExtensionConfig";
 import KeyboardShortcuts from "../KeyboardShortcuts/ExtensionConfig";
 import Link from "../Link/ExtensionConfig";
 import Mention, { createMentionSuggestions } from "../Mention/ExtensionConfig";
@@ -85,11 +86,13 @@ const useCustomExtensions = ({
       bulletList: false,
       blockquote: options.includes(EDITOR_OPTIONS.BLOCKQUOTE),
       orderedList: options.includes(EDITOR_OPTIONS.LIST_ORDERED),
+      italic: false,
       history: !collaborationProvider,
       heading: { levels: buildLevelsFromOptions(options) },
     }),
     TextStyle,
     Underline,
+    Italic,
     KeyboardShortcuts.configure({
       onSubmit,
       shortcuts: keyboardShortcuts,


### PR DESCRIPTION
- Fixes #1353 

**Description**

- Extended the Italics extension and removed the underscore mark from the input rules. Additionally, disabled the italics extension from the StarterKit.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
