### PR TITLE
Added close button and outside click functionality to exit from upload image/video modal

### DIFF
--- a/src/components/Editor/MediaUploader/index.jsx
+++ b/src/components/Editor/MediaUploader/index.jsx
@@ -55,7 +55,7 @@ const MediaUploader = ({ mediaUploader, onClose, editor, unsplashApiKey }) => {
     <Modal
       {...{ isOpen }}
       className="ne-media-uploader-modal"
-      closeButton={false}
+      closeButton={not(isUploading)}
       closeOnOutsideClick={not(isUploading)}
       onClose={handleClose}
     >

--- a/src/styles/editor/_media-uploader.scss
+++ b/src/styles/editor/_media-uploader.scss
@@ -12,6 +12,7 @@
 
   .neeto-ui-tab__wrapper {
     padding: 0 16px;
+    margin-top: 1.2rem;
   }
 
   .ne-tab__wrapper {


### PR DESCRIPTION
- Fixes #1367 

**Description**
- Added a close button in the image upload modal and video upload modal. Additionally, improved the alignment of the image modal TABS with the close button.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
