### PR TITLE
Ensure addonCommands is applicable for both slash commands and menu

### DIFF
--- a/src/components/Editor/CustomExtensions/SlashCommands/utils.js
+++ b/src/components/Editor/CustomExtensions/SlashCommands/utils.js
@@ -1,6 +1,5 @@
-import { assoc } from "ramda";
-
 import { EDITOR_OPTIONS } from "common/constants";
+import { assoc } from "ramda";
 
 import { MENU_ITEMS } from "./constants";
 
@@ -47,5 +46,11 @@ export const buildCommandItems = ({
     options.includes(optionName)
   );
 
-  return [...permittedCommandItems, ...addonCommands];
+  const adddonCommandItems = addonCommands.map(command => ({
+    ...command,
+    title: command.label,
+    Icon: command.icon,
+  }));
+
+  return [...permittedCommandItems, ...adddonCommandItems];
 };

--- a/stories/Examples/Customize-options/Custom-slash-commands.stories.mdx
+++ b/stories/Examples/Customize-options/Custom-slash-commands.stories.mdx
@@ -47,21 +47,21 @@ like canned response as well.
     menuType="bubble"
     addonCommands={[
       {
-        title: "Canned Responses",
+        label: "Canned Responses",
         tooltip: "Canned Responses",
-        Icon: CannedResponses,
+        icon: CannedResponses,
         description: "Select a canned response",
         optionName: "canned-responses",
         items: [
           {
-            title: "Feedback",
+            label: "Feedback",
             description: "Thank you for your feedback.",
             command: ({ editor, range }) => {
               editor.commands.setContent("Thank you for your feedback.");
             },
           },
           {
-            title: "Thanks",
+            label: "Thanks",
             description: "We are hapy to help you.",
             command: ({ editor, range }) => {
               editor.commands.setContent("We are happy to help you.");

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,8 +17,8 @@ import Variables from "components/Editor/CustomExtensions/Variable/index";
 import { EDITOR_OPTIONS as EDITOR_OPTIONS_VALUES } from "common/constants"
 
 interface Command {
-  title: string;
-  Icon: Function;
+  label: string;
+  icon: Function;
   description?: string;
   optionName: string;
   active?: ({ editor: TiptapEditor }) => boolean;


### PR DESCRIPTION
- Fixes #1376 

**Description**

- Ensure addonCommands is applicable for both slash commands and menu.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
