### PR TITLE
Fixed secondary dropdown emoji issue

### DIFF
--- a/src/components/Editor/Menu/Fixed/components/EmojiOption.jsx
+++ b/src/components/Editor/Menu/Fixed/components/EmojiOption.jsx
@@ -18,7 +18,6 @@ const EmojiOption = ({
   <Dropdown
     buttonStyle="text"
     closeOnSelect={false}
-    dropdownProps={{ classNames: "neeto-editor-fixed-menu__emoji-dropdown" }}
     icon={Smiley}
     isOpen={isActive}
     position={isSecondaryMenu ? "left-start" : "bottom-start"}
@@ -32,6 +31,10 @@ const EmojiOption = ({
     customTarget={
       isSecondaryMenu && <SecondaryMenuTarget {...{ label }} icon={Smiley} />
     }
+    dropdownProps={{
+      classNames: "neeto-editor-fixed-menu__emoji-dropdown",
+      onClick: e => isSecondaryMenu && e.stopPropagation(),
+    }}
     onClose={() => setActive(false)}
     onClick={e => {
       setActive(active => !active);


### PR DESCRIPTION
- Fixes #1394 

**Description**
- Prevented the onClick event on the emoji picker from "bubbling up" to its parent through the DOM hierarchy.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
