### PR TITLE
Improve Bubble menu styles

### DIFF
--- a/src/components/Editor/Menu/Bubble/Options.jsx
+++ b/src/components/Editor/Menu/Bubble/Options.jsx
@@ -1,12 +1,12 @@
 import { EDITOR_OPTIONS } from "common/constants";
-import { Link, Column } from "neetoicons";
+import { Link, Column, Down } from "neetoicons";
 import { Dropdown } from "neetoui";
 import { useTranslation } from "react-i18next";
 
 import LinkOption from "./LinkOption";
 import TableOption from "./TableOption";
 import {
-  getNodeType,
+  getNodeIcon,
   getTextMenuDropdownOptions,
   renderOptionButton,
   buildBubbleMenuOptions,
@@ -36,7 +36,7 @@ const Options = ({
   const { Menu, MenuItem } = Dropdown;
 
   const dropdownOptions = getTextMenuDropdownOptions({ editor, options });
-  const nodeType = getNodeType(dropdownOptions);
+  const Icon = getNodeIcon(dropdownOptions);
   const isEmojiActive = options.includes(EDITOR_OPTIONS.EMOJI);
   const isTextColorOptionActive = options.includes(EDITOR_OPTIONS.TEXT_COLOR);
   const isLinkActive = options.includes(EDITOR_OPTIONS.LINK);
@@ -86,13 +86,29 @@ const Options = ({
       <Dropdown
         buttonSize="small"
         buttonStyle="text"
-        label={nodeType}
+        label={Icon}
         strategy="fixed"
+        buttonProps={{
+          icon: Icon,
+          iconPosition: "left",
+          iconSize: 22,
+          label: <Down size={12} />,
+          "data-cy": "neeto-editor-fixed-menu-font-size-option",
+          style: "text",
+          size: "small",
+          className:
+            "neeto-editor-bubble-menu__item neeto-editor-font-size__wrapper",
+        }}
       >
-        <Menu>
-          {dropdownOptions.map(({ optionName, command }) => (
-            <MenuItem.Button key={optionName} onClick={command}>
-              {optionName}
+        <Menu className="neeto-ui-flex neeto-ui-gap-1 neeto-editor-menu-font-size-options">
+          {dropdownOptions.map(({ optionName, command, icon: Icon }) => (
+            <MenuItem.Button
+              className="neeto-editor-menu-font-size-options__item-btn"
+              key={optionName}
+              tooltipProps={{ content: optionName, position: "bottom" }}
+              onClick={command}
+            >
+              <Icon size={22} />
             </MenuItem.Button>
           ))}
         </Menu>

--- a/src/components/Editor/Menu/Bubble/TableOption.jsx
+++ b/src/components/Editor/Menu/Bubble/TableOption.jsx
@@ -32,7 +32,6 @@ const TableOption = ({ editor, handleClose }) => {
           autoFocus
           data-cy="neeto-editor-fixed-menu-table-option-input"
           min="1"
-          placeholder={t("neetoEditor.placeholders.rows")}
           type="number"
           value={rows}
           onChange={withEventTargetValue(setRows)}
@@ -45,7 +44,6 @@ const TableOption = ({ editor, handleClose }) => {
         <input
           data-cy="neeto-editor-bubble-menu-table-option-input"
           min="1"
-          placeholder={t("neetoEditor.placeholders.columns")}
           type="number"
           value={columns}
           onChange={withEventTargetValue(setColumns)}
@@ -55,12 +53,14 @@ const TableOption = ({ editor, handleClose }) => {
         <Button
           data-cy="neeto-editor-bubble-menu-table-option-create-button"
           icon={Check}
+          size="small"
           style="secondary"
           onClick={handleSubmit}
         />
         <Button
           data-cy="neeto-editor-bubble-menu-table-option-create-button"
           icon={Close}
+          size="small"
           style="secondary"
           onClick={handleClose}
         />

--- a/src/components/Editor/Menu/Bubble/index.jsx
+++ b/src/components/Editor/Menu/Bubble/index.jsx
@@ -57,7 +57,7 @@ const Bubble = ({
             setIsLinkOptionActive(false);
             setIsTableOptionActive(false);
           },
-          theme: "neeto-editor-bubble-menu",
+          theme: "light neeto-editor-bubble-menu-tippy-box",
           maxWidth: 500,
         }}
       >

--- a/src/components/Editor/Menu/Bubble/utils.jsx
+++ b/src/components/Editor/Menu/Bubble/utils.jsx
@@ -17,6 +17,10 @@ import {
   MediaVideo,
   Undo,
   Redo,
+  TextP,
+  TextH1,
+  TextH2,
+  TextH3,
 } from "neetoicons";
 import { Button } from "neetoui";
 import { assoc, fromPairs, not, prop } from "ramda";
@@ -195,34 +199,28 @@ export const getTextMenuDropdownOptions = ({ editor, options }) => {
   const textOptions = {
     [EDITOR_OPTIONS.H1]: {
       optionName: "Heading 1",
+      icon: TextH1,
       active: editor.isActive("heading", { level: 1 }),
       command: () =>
         editor.chain().focus().setNode("heading", { level: 1 }).run(),
     },
     [EDITOR_OPTIONS.H2]: {
       optionName: "Heading 2",
+      icon: TextH2,
       active: editor.isActive("heading", { level: 2 }),
       command: () =>
         editor.chain().focus().setNode("heading", { level: 2 }).run(),
     },
     [EDITOR_OPTIONS.H3]: {
       optionName: "Heading 3",
+      icon: TextH3,
       active: editor.isActive("heading", { level: 3 }),
       command: () =>
         editor.chain().focus().setNode("heading", { level: 3 }).run(),
     },
-    [EDITOR_OPTIONS.LIST_ORDERED]: {
-      optionName: "Ordered List",
-      active: editor.isActive("orderedList"),
-      command: () => editor.chain().focus().toggleOrderedList().run(),
-    },
-    [EDITOR_OPTIONS.LIST_BULLETS]: {
-      optionName: "Bulleted List",
-      active: editor.isActive("bulletList"),
-      command: () => editor.chain().focus().toggleBulletList().run(),
-    },
     [EDITOR_OPTIONS.PARAGRAPH]: {
       optionName: "Text",
+      icon: TextP,
       active: editor.isActive("paragraph"),
       command: () => editor.chain().focus().setNode("paragraph").run(),
     },
@@ -237,8 +235,8 @@ export const getTextMenuDropdownOptions = ({ editor, options }) => {
   return result;
 };
 
-export const getNodeType = options =>
-  options.find(prop("active"))?.optionName || "Text";
+export const getNodeIcon = options =>
+  options.find(prop("active"))?.icon || TextP;
 
 export const renderOptionButton = ({
   tooltip,
@@ -249,16 +247,16 @@ export const renderOptionButton = ({
   highlight,
 }) => (
   <Button
+    className="neeto-editor-bubble-menu__item"
     data-cy={`neeto-editor-bubble-menu-${optionName}-option`}
     icon={Icon}
     key={optionName}
-    size="small"
+    size="medium"
     style={active ? "secondary" : "text"}
     tooltipProps={{
       content: tooltip,
       position: "bottom",
       theme: "dark",
-      delay: [500],
     }}
     onClick={command}
     {...generateFocusProps(highlight)}

--- a/src/components/Editor/Menu/Fixed/components/TextColorOption.jsx
+++ b/src/components/Editor/Menu/Fixed/components/TextColorOption.jsx
@@ -58,7 +58,7 @@ const TextColorOption = ({
       position={isSecondaryMenu ? "left-start" : "bottom-start"}
       buttonProps={{
         tabIndex: -1,
-        tooltipProps: { content: tooltipContent ?? label },
+        tooltipProps: { content: tooltipContent ?? label, position: "bottom" },
         className:
           "neeto-editor-fixed-menu__item neeto-editor-text-color-option",
       }}

--- a/src/styles/editor/menu.scss
+++ b/src/styles/editor/menu.scss
@@ -214,46 +214,75 @@
   padding-right: 4px !important;
 }
 
+.tippy-box[data-theme~=neeto-editor-bubble-menu-tippy-box] {
+  box-shadow: none !important;
+}
+
+.tippy-box[data-theme~=neeto-editor-bubble-menu-tippy-box] .tippy-content {
+  padding: 0 !important;
+}
+
 .neeto-editor-bubble-menu {
   position: relative;
   display: flex;
-  gap: 1px;
+  gap: 0;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   border-radius: var(--neeto-ui-rounded);
-  background: rgb(var(--neeto-ui-gray-800));
-  padding: 0 4px;
+  background: rgb(var(--neeto-ui-white));
+  padding: 0;
+  border: 1px solid rgb(var(--neeto-ui-gray-400));
+  overflow-x: auto;
 
-  button.neeto-ui-btn--style-text {
-    color: rgb(var(--neeto-ui-gray-200));
+  &>.neeto-editor-bubble-menu__item:first-child,
+  &>.neeto-editor-fixed-menu__item:first-child {
+    border-top-left-radius: var(--neeto-ui-rounded);
+    border-bottom-left-radius: var(--neeto-ui-rounded);
+  }
+
+  &>.neeto-editor-bubble-menu__item:last-child,
+  &>.neeto-editor-fixed-menu__item:last-child {
+    border-top-right-radius: var(--neeto-ui-rounded);
+    border-bottom-right-radius: var(--neeto-ui-rounded);
+  }
+
+  button.neeto-editor-bubble-menu__item,
+  button.neeto-editor-fixed-menu__item {
+    color: rgb(var(--neeto-ui-black)) !important;
     min-width: fit-content;
+    width: 36px;
+    height: 36px;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+
+    --neeto-ui-btn-border-radius: 0;
+    --neeto-ui-btn-icon-size: 22px;
+    --neeto-ui-btn-padding-x: 0;
+    --neeto-ui-btn-padding-y: 0;
+    --neeto-ui-btn-focus-box-shadow: none;
+
+    .neeto-ui-btn__icon {
+      color: rgb(var(--neeto-ui-black));
+
+      path {
+        stroke-width: 1.5px;
+      }
+    }
 
     &:hover,
     &:active,
     &.active {
-      color: rgb(var(--neeto-ui-gray-200)) !important;
-      background-color: rgb(var(--neeto-ui-gray-600)) !important;
+      background-color: rgb(var(--neeto-ui-gray-100));
     }
   }
 
-  button.neeto-ui-btn--style-secondary {
-    min-width: fit-content;
-    background-color: rgb(var(--neeto-ui-gray-400));
-  }
+  button.neeto-editor-bubble-menu__item.neeto-ui-btn--style-secondary {
+    background-color: rgb(var(--neeto-ui-accent-100)) !important;
 
-  .neeto-ui-dropdown__popup {
-    background-color: rgb(var(--neeto-ui-gray-700));
-
-    &-menu-item-btn {
-      color: rgb(var(--neeto-ui-gray-200)) !important;
-      background-color: inherit !important;
-
-      &:hover,
-      &:active,
-      &.active {
-        background-color: rgb(var(--neeto-ui-gray-600)) !important;
-      }
+    .neeto-ui-btn__icon {
+      color: rgb(var(--neeto-ui-accent-800)) !important;
     }
   }
 
@@ -263,14 +292,21 @@
     align-items: center;
     justify-content: space-between;
     padding: 6px;
-    gap: 8px;
+    gap: 6px;
 
     .neeto-editor-bubble-menu-link__input {
       background-color: transparent;
       outline: none;
-      line-height: 20px;
+      height: 28px;
       width: 100%;
-      color: rgb(var(--neeto-ui-gray-200));
+      font-size: var(--neeto-ui-input-font-size);
+      transition: var(--neeto-ui-transition);
+      border-radius: var(--neeto-ui-input-border-radius);
+      border: var(--neeto-ui-input-border-width) solid var(--neeto-ui-input-border-color);
+      background-color: var(--neeto-ui-input-bg-color);
+      color: var(--neeto-ui-input-color);
+      outline: none;
+      line-height: 1.2;
 
       &::placeholder {
         color: rgba(var(--neeto-ui-white, 0.4));
@@ -291,32 +327,37 @@
   .neeto-editor-bubble-menu__table {
     max-width: 256px;
     display: flex;
-    align-items: center;
+    align-items: start;
     justify-content: space-between;
     padding: 4px;
     gap: 6px;
 
     input {
-      background-color: rgba(var(--neeto-ui-gray-400), 0.2);
+      font-size: var(--neeto-ui-input-font-size);
+      transition: var(--neeto-ui-transition);
+      border-radius: var(--neeto-ui-input-border-radius);
+      border: var(--neeto-ui-input-border-width) solid var(--neeto-ui-input-border-color);
+      background-color: var(--neeto-ui-input-bg-color);
+      color: var(--neeto-ui-input-color);
       outline: none;
-      line-height: 20px;
+      line-height: 1.2;
       width: 60px;
-      height: 24px;
+      height: 28px;
       padding: 3px 5px;
 
       &::placeholder {
-        color: rgba(var(--neeto-ui-white, 0.4));
+        color: rgb(var(--neeto-ui-gray-500));
       }
     }
 
     &__menu-item {
       display: flex;
       flex-direction: column;
-      gap: 4px;
+      gap: 6px;
     }
 
     &__input-label {
-      color: white;
+      color: rgb(var(--neeto-ui-gray-800));
     }
 
     &__buttons {

--- a/stories/Walkthroughs/Menu-types/BubbleMenu.stories.mdx
+++ b/stories/Walkthroughs/Menu-types/BubbleMenu.stories.mdx
@@ -26,23 +26,5 @@ menu. Bubble Menu option that appears when user selects part of text.
 #### **Example**
 
 <Canvas>
-  <Editor
-    menuType="bubble"
-    addons={[
-      "highlight",
-      "emoji",
-      "code-block",
-      "block-quote",
-      "image-upload",
-      "image-upload-unsplash",
-      "video-upload",
-      "video-embed",
-      "paste-unformatted",
-      "undo",
-      "redo",
-      "attachments",
-      "table",
-      "text-color",
-    ]}
-  />
+  <Editor menuType="bubble" />
 </Canvas>

--- a/stories/Walkthroughs/Menu-types/BubbleMenu.stories.mdx
+++ b/stories/Walkthroughs/Menu-types/BubbleMenu.stories.mdx
@@ -26,5 +26,23 @@ menu. Bubble Menu option that appears when user selects part of text.
 #### **Example**
 
 <Canvas>
-  <Editor menuType="bubble" />
+  <Editor
+    menuType="bubble"
+    addons={[
+      "highlight",
+      "emoji",
+      "code-block",
+      "block-quote",
+      "image-upload",
+      "image-upload-unsplash",
+      "video-upload",
+      "video-embed",
+      "paste-unformatted",
+      "undo",
+      "redo",
+      "attachments",
+      "table",
+      "text-color",
+    ]}
+  />
 </Canvas>


### PR DESCRIPTION
- Fixes #1393

**Description**

- Updated the Bubble menu styles to match the default toolbar style.

[Demo](https://praveen-murali.neetorecord.com/watch/959e7c4df5bb7e21f542)

### After

<img width="404" alt="Screenshot 2025-05-20 at 1 57 34 PM" src="https://github.com/user-attachments/assets/cc985696-7009-46e7-a6bd-5d9945df0b98" />

<img width="406" alt="Screenshot 2025-05-20 at 2 02 58 PM" src="https://github.com/user-attachments/assets/807df413-d351-47e7-9add-d6f8eab0eb2a" />

### Before

<img width="367" alt="Screenshot 2025-05-20 at 1 57 20 PM" src="https://github.com/user-attachments/assets/e020cdcf-078b-4f7d-bb9b-2791cf7ecb4b" />
</br>
<img width="381" alt="Screenshot 2025-05-20 at 1 58 03 PM" src="https://github.com/user-attachments/assets/91cf1889-af90-4daa-ad2a-820a365a128f" />
</br>
<img width="320" alt="Screenshot 2025-05-20 at 1 58 18 PM" src="https://github.com/user-attachments/assets/ab0e69d0-6489-426f-9091-e3f5f5f03010" />


**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->

