### PR TITLE
Set the proper key to the Slash menu items to prevent incorrect renders

### DIFF
--- a/src/components/Editor/CustomExtensions/SlashCommands/Menu.jsx
+++ b/src/components/Editor/CustomExtensions/SlashCommands/Menu.jsx
@@ -106,7 +106,7 @@ class Menu extends React.Component {
           const nodeElement = (
             <MenuItem
               {...{ index, item }}
-              key={item.title}
+              key={item.optionName}
               selectItem={() => isLeafNode && this.selectItem(index)}
               selectedIndex={isCurrentMenuActive ? selectedIndex : -1}
               onHover={() => this.setState({ selectedIndex: index })}
@@ -118,7 +118,7 @@ class Menu extends React.Component {
           return (
             <Tippy
               interactive
-              key={item.title}
+              key={item.optionName}
               placement="right"
               visible={selectedIndex === index}
               content={
@@ -152,8 +152,8 @@ const MenuItem = forwardRef(
 
     return (
       <div
-        data-cy={`neeto-editor-command-list-item-${index}`}
         {...{ ref }}
+        data-cy={`neeto-editor-command-list-item-${index}`}
         className={classnames("neeto-editor-slash-commands__item", {
           active: index === selectedIndex,
         })}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -88,7 +88,7 @@
       "h5": "H5",
       "heading5": "Heading 5",
       "h5Description": "Add a sub-heading of level 5.",
-      "h6": "H3",
+      "h6": "H6",
       "h6Description": "Add a sub-heading of level 6.",
       "numberedList": "Numbered list",
       "numberedListDescription": "Add a list with numbering.",


### PR DESCRIPTION
- Fixes #1385 

**Description**

- Set the proper key to the Slash menu items to prevent incorrect renders.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
