### PR TITLE
Replaced the .at() syntax to avoid Bing Search Crawler's older environment

### DIFF
--- a/src/components/Editor/Menu/Fixed/components/FontSizeOption.jsx
+++ b/src/components/Editor/Menu/Fixed/components/FontSizeOption.jsx
@@ -34,7 +34,7 @@ const FontSizeOption = ({
 
   const menuOptions = [
     ...filterBy({ key: key => options.includes(key) }, FONT_SIZE_OPTIONS),
-    FONT_SIZE_OPTIONS.at(-1),
+    FONT_SIZE_OPTIONS[FONT_SIZE_OPTIONS.length - 1],
   ];
 
   return (


### PR DESCRIPTION
- Fixes #1391 

**Description**

The User Agent (`Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/112.0.0.0 Safari/537.36`) was a Bing search engine crawler.

The explanation that I could come up with is that it is using an older, incompatible environment where the .at() syntax is not supported.

One of my ideas is to update the ESBuild config to compile the code to an older browserslist. This will lead to an increase in bundle size across Neeto.

Since this is the first occurrence, I'll edit the NeetoEditor code to use an alternate syntax.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
