### PR TITLE
Prevent highlight of lines when the line number to be highlighted is more than the number of lines

### DIFF
--- a/src/components/EditorContent/utils/index.js
+++ b/src/components/EditorContent/utils/index.js
@@ -47,6 +47,7 @@ const highlightLinesCode = (code, options) => {
   // eslint-disable-next-line @bigbinary/neeto/use-array-methods
   for (const option of options) {
     for (let j = option.start; j <= option.end; ++j) {
+      if (j >= lines.length) return;
       lines[j].style.backgroundColor = option.color;
       lines[j].style.minWidth = `${
         scroll_width - paddingLeft - paddingRight


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-editor/issues/1428

**Description**

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
