### PR TITLE
Improvements to Slash Commands UI

### DIFF
--- a/src/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/SlashCommands/ExtensionConfig.js
@@ -83,7 +83,7 @@ export default {
                     arrow: false,
                     zIndex: 99999,
                     role: "dropdown",
-                    theme: "neeto-editor-slash-menu",
+                    theme: "light neeto-editor-slash-commands-tippy",
                   });
 
                   highlightFocussedNode();

--- a/src/components/Editor/CustomExtensions/SlashCommands/Menu.jsx
+++ b/src/components/Editor/CustomExtensions/SlashCommands/Menu.jsx
@@ -151,7 +151,7 @@ const MenuItem = forwardRef(
     const { Icon } = item;
 
     return (
-      <div
+      <button
         {...{ ref }}
         data-cy={`neeto-editor-command-list-item-${index}`}
         className={classnames("neeto-editor-slash-commands__item", {
@@ -161,15 +161,15 @@ const MenuItem = forwardRef(
         onMouseEnter={onHover}
       >
         {Icon && <Icon size={20} />}
-        <div className="neeto-editor-slash-commands__item-content">
-          <h5 data-cy="neeto-editor-command-list-item-block-heading">
+        <span className="neeto-editor-slash-commands__item-content">
+          <span
+            className="neeto-editor-slash-commands__item-title"
+            data-cy="neeto-editor-command-list-item-block-heading"
+          >
             {item.title}
-          </h5>
-          <p data-cy="neeto-editor-command-list-item-block-description">
-            {item.description}
-          </p>
-        </div>
-      </div>
+          </span>
+        </span>
+      </button>
     );
   }
 );

--- a/src/components/Editor/CustomExtensions/SlashCommands/constants.js
+++ b/src/components/Editor/CustomExtensions/SlashCommands/constants.js
@@ -2,9 +2,12 @@ import { EDITOR_OPTIONS } from "common/constants";
 import { t } from "i18next";
 import { noop } from "neetocist";
 import {
-  Paragraph,
+  TextP,
   TextH1,
   TextH2,
+  TextH3,
+  TextH4,
+  TextH5,
   ListDot,
   ListNumber,
   Blockquote,
@@ -13,7 +16,6 @@ import {
   Smiley,
   Minus,
   Video,
-  Text,
   Notes,
   MediaVideo,
   Column,
@@ -24,14 +26,14 @@ export const MENU_ITEMS = [
     optionName: EDITOR_OPTIONS.PARAGRAPH,
     title: t("neetoEditor.menu.normalText"),
     description: t("neetoEditor.menu.normalTextDescription"),
-    Icon: Paragraph,
+    Icon: TextP,
     command: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).setNode("paragraph").run();
     },
   },
   {
     optionName: EDITOR_OPTIONS.H1,
-    title: t("neetoEditor.menu.h1"),
+    title: t("neetoEditor.menu.heading1"),
     description: t("neetoEditor.menu.h1Description"),
     Icon: TextH1,
     command: ({ editor, range }) => {
@@ -45,7 +47,7 @@ export const MENU_ITEMS = [
   },
   {
     optionName: EDITOR_OPTIONS.H2,
-    title: t("neetoEditor.menu.h2"),
+    title: t("neetoEditor.menu.heading2"),
     description: t("neetoEditor.menu.h2Description"),
     Icon: TextH2,
     command: ({ editor, range }) => {
@@ -59,9 +61,9 @@ export const MENU_ITEMS = [
   },
   {
     optionName: EDITOR_OPTIONS.H3,
-    title: t("neetoEditor.menu.h3"),
+    title: t("neetoEditor.menu.heading3"),
     description: t("neetoEditor.menu.h3Description"),
-    Icon: Text,
+    Icon: TextH3,
     command: ({ editor, range }) => {
       editor
         .chain()
@@ -73,9 +75,9 @@ export const MENU_ITEMS = [
   },
   {
     optionName: EDITOR_OPTIONS.H4,
-    title: t("neetoEditor.menu.h4"),
+    title: t("neetoEditor.menu.heading4"),
     description: t("neetoEditor.menu.h4Description"),
-    Icon: Text,
+    Icon: TextH4,
     command: ({ editor, range }) => {
       editor
         .chain()
@@ -87,29 +89,15 @@ export const MENU_ITEMS = [
   },
   {
     optionName: EDITOR_OPTIONS.H5,
-    title: t("neetoEditor.menu.h5"),
+    title: t("neetoEditor.menu.heading5"),
     description: t("neetoEditor.menu.h5Description"),
-    Icon: Text,
+    Icon: TextH5,
     command: ({ editor, range }) => {
       editor
         .chain()
         .focus()
         .deleteRange(range)
         .setNode("heading", { level: 5 })
-        .run();
-    },
-  },
-  {
-    optionName: EDITOR_OPTIONS.H6,
-    title: t("neetoEditor.menu.h6"),
-    description: t("neetoEditor.menu.h6Description"),
-    Icon: Text,
-    command: ({ editor, range }) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .setNode("heading", { level: 6 })
         .run();
     },
   },

--- a/src/components/Editor/CustomExtensions/Table/TableActionMenu.jsx
+++ b/src/components/Editor/CustomExtensions/Table/TableActionMenu.jsx
@@ -29,7 +29,7 @@ const TableActionMenu = ({ editor }) => {
         arrow: false,
         offset: [10, 10],
         zIndex: 99999,
-        theme: "neeto-editor-bubble-menu",
+        theme: "light neeto-editor-bubble-menu-tippy-box",
         popperOptions: {
           modifiers: [{ name: "flip", enabled: false }],
         },
@@ -44,6 +44,7 @@ const TableActionMenu = ({ editor }) => {
             !isHidden && (
               <Button
                 {...{ icon }}
+                className="neeto-editor-table-bubble-menu__item"
                 iconSize={18}
                 key={label}
                 size="small"

--- a/src/styles/editor/_commands.scss
+++ b/src/styles/editor/_commands.scss
@@ -1,5 +1,13 @@
+.tippy-box[data-theme~=neeto-editor-slash-commands-tippy] {
+  border: 1px solid rgb(var(--neeto-ui-gray-400));
+
+  .tippy-content {
+    padding: 0 !important;
+  }
+}
+
 .neeto-editor-slash-commands__wrapper {
-  padding: 12px;
+  padding: 8px;
   overflow-y: auto;
   max-height: 384px;
   width: 256px;
@@ -18,26 +26,40 @@
     justify-content: flex-start;
     align-items: center;
     padding: 8px 12px;
-    gap: 12px;
+    gap: 8px;
     border-radius: var(--neeto-ui-rounded);
     transition: var(--neeto-ui-transition);
     cursor: pointer;
-    color: rgb(var(--neeto-ui-white));
+    color: rgb(var(--neeto-ui-gray-800));
+    box-shadow: none;
+    border: none;
+    outline: none;
 
     &:hover,
+    &:focus-visible,
     &.active {
-      background-color: rgb(var(--neeto-ui-gray-700));
+      color: rgb(var(--neeto-ui-black));
+      background-color: rgb(var(--neeto-ui-gray-200));
+      box-shadow: none;
+      border: none;
+      outline: none;
     }
 
     .neeto-editor-slash-commands__item-content {
-      h5 {
-        font-size: var(--neeto-ui-text-sm);
-        font-weight: var(--neeto-ui-font-semibold);
-        line-height: var(--neeto-ui-leading-normal);
+      text-align: left;
+
+      .neeto-editor-slash-commands__item-title {
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 1.2;
+        text-align: left;
       }
-      p {
-        font-size: var(--neeto-ui-text-xs);
-        color: rgb(var(--neeto-ui-gray-300));
+
+      .neeto-editor-slash-commands__item-description {
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 1.2;
+        text-align: left;
       }
     }
   }
@@ -45,6 +67,7 @@
 
 .tippy-box[data-theme~="neeto-editor-mentions-tooltip"] {
   border: 1px solid rgb(var(--neeto-ui-gray-400));
+
   .tippy-content {
     padding: 0;
     max-height: none;

--- a/src/styles/editor/menu.scss
+++ b/src/styles/editor/menu.scss
@@ -236,19 +236,22 @@
   overflow-x: auto;
 
   &>.neeto-editor-bubble-menu__item:first-child,
-  &>.neeto-editor-fixed-menu__item:first-child {
+  &>.neeto-editor-fixed-menu__item:first-child,
+  &>.neeto-editor-table-bubble-menu__item:first-child {
     border-top-left-radius: var(--neeto-ui-rounded);
     border-bottom-left-radius: var(--neeto-ui-rounded);
   }
 
   &>.neeto-editor-bubble-menu__item:last-child,
-  &>.neeto-editor-fixed-menu__item:last-child {
+  &>.neeto-editor-fixed-menu__item:last-child,
+  &>.neeto-editor-table-bubble-menu__item:last-child {
     border-top-right-radius: var(--neeto-ui-rounded);
     border-bottom-right-radius: var(--neeto-ui-rounded);
   }
 
   button.neeto-editor-bubble-menu__item,
-  button.neeto-editor-fixed-menu__item {
+  button.neeto-editor-fixed-menu__item,
+  button.neeto-editor-table-bubble-menu__item {
     color: rgb(var(--neeto-ui-black)) !important;
     min-width: fit-content;
     width: 36px;


### PR DESCRIPTION
- Fixes #1421 

**Description**

- Updated the Slash Menu to use the light theme to match the rest of the menu styles.
- Made the spacing more compact to accommodate the new options.
- Improved spacing and visual hierarchy.
- Fixed semantic issues, enabled keyboard navigation, and refined the styles.

### Light mode and Dark mode

<img width="338" alt="Screenshot 2025-06-09 at 6 56 55 PM" src="https://github.com/user-attachments/assets/5357a0f1-007d-41c6-a3c6-60783538437e" />
<img width="314" alt="Screenshot 2025-06-09 at 6 57 45 PM" src="https://github.com/user-attachments/assets/4dc21497-3fa0-4897-8440-2335f5a1afa3" />
<img width="390" alt="Screenshot 2025-06-09 at 7 06 31 PM" src="https://github.com/user-attachments/assets/78600f62-084f-42af-a24b-d112d294a529" />
<img width="399" alt="Screenshot 2025-06-09 at 7 06 40 PM" src="https://github.com/user-attachments/assets/3f35f3db-bcd9-44c4-beac-784fc7b436ac" />

### Before

<img width="342" alt="Screenshot 2025-06-09 at 7 16 15 PM" src="https://github.com/user-attachments/assets/b6f2bcae-ed6c-4bd2-879f-6b5ee88bd52f" />
<img width="468" alt="Screenshot 2025-06-09 at 7 17 45 PM" src="https://github.com/user-attachments/assets/b2ff0dfe-05ae-43dc-bda7-dd3835284f98" />

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
