### PR TITLE
Use the id to calculate the position of the empty image node during upload failures

### DIFF
--- a/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Image/ExtensionConfig.js
@@ -215,8 +215,8 @@ export default Node.create({
 
               images.forEach(async image => {
                 let emptyImageNode;
+                const id = Math.random().toString(36).substring(7);
                 try {
-                  const id = Math.random().toString(36).substring(7);
                   emptyImageNode = schema.nodes.image.create({
                     id,
                     src: "",
@@ -242,9 +242,21 @@ export default Node.create({
                 } catch (error) {
                   // eslint-disable-next-line no-console
                   console.error("Failed to insert the image", error);
-                  const tr = view.state.tr
-                    .delete(currentPos, currentPos + emptyImageNode.nodeSize)
-                    .setMeta("addToHistory", false);
+
+                  const doc = view.state.doc;
+                  const tr = view.state.tr;
+                  doc.descendants((node, pos) => {
+                    if (node.type.name === "image" && node.attrs.id === id) {
+                      tr.delete(pos, pos + emptyImageNode.nodeSize).setMeta(
+                        "addToHistory",
+                        false
+                      );
+
+                      return false;
+                    }
+
+                    return true;
+                  });
                   view.dispatch(tr);
 
                   if (error.message === LARGE_IMAGE_ERROR) {


### PR DESCRIPTION
- Fixes #1410 

**Description**

- Use the id to calculate the position of the empty image node during upload failures. This is necessary since the user might continue to type when the image is being uploaded. This will cause the currentPos to be out of date.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
