### PR TITLE
Added placeholder for slash commands at the start of the editor content

### DIFF
--- a/src/components/Editor/CustomExtensions/Placeholder/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/Placeholder/ExtensionConfig.js
@@ -12,6 +12,9 @@ const Placeholder = Extension.create({
       emptyEditorClass: "is-editor-empty",
       emptyNodeClass: "is-empty",
       placeholder: t("neetoEditor.placeholders.writeSomething"),
+      slashCommandsPlaceholder: t(
+        "neetoEditor.placeholders.writeSlashForCommands"
+      ),
       showOnlyWhenEditable: true,
       showOnlyCurrent: false,
       includeChildren: false,
@@ -47,13 +50,22 @@ const Placeholder = Extension.create({
               ) {
                 const classes = [this.options.emptyNodeClass];
 
+                let placeholderText = this.options.placeholder;
+
                 if (this.editor.isEmpty) {
                   classes.push(this.options.emptyEditorClass);
+
+                  if (
+                    this.options.isSlashCommandsActive &&
+                    !this.options.placeholder
+                  ) {
+                    placeholderText = this.options.slashCommandsPlaceholder;
+                  }
                 }
 
                 const decoration = Decoration.node(pos, pos + node.nodeSize, {
                   class: classes.join(" "),
-                  "data-placeholder": this.options.placeholder,
+                  "data-placeholder": placeholderText,
                 });
                 decorations.push(decoration);
               }

--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -78,10 +78,7 @@ const useCustomExtensions = ({
     Link.configure({
       HTMLAttributes: { target: openLinkInNewTab ? "_blank" : null },
     }),
-    Placeholder.configure({
-      placeholder: placeholder || "",
-      isSlashCommandsActive,
-    }),
+    Placeholder.configure({ placeholder, isSlashCommandsActive }),
     StarterKit.configure({
       document: false,
       codeBlock: false,

--- a/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
+++ b/src/components/Editor/CustomExtensions/hooks/useCustomExtensions.js
@@ -78,7 +78,10 @@ const useCustomExtensions = ({
     Link.configure({
       HTMLAttributes: { target: openLinkInNewTab ? "_blank" : null },
     }),
-    Placeholder.configure({ placeholder }),
+    Placeholder.configure({
+      placeholder: placeholder || "",
+      isSlashCommandsActive,
+    }),
     StarterKit.configure({
       document: false,
       codeBlock: false,

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -88,7 +88,7 @@ const Editor = (
   const isBubbleMenuActive = menuType === "bubble";
   const isSlashCommandsActive =
     !hideSlashCommands || (isBubbleMenuActive && !hideSlashCommands);
-  const isPlaceholderActive = !!placeholder;
+  const isPlaceholderActive = !!placeholder || isSlashCommandsActive;
   const [isAddLinkActive, setIsAddLinkActive] = useState(false);
   const [mediaUploader, setMediaUploader] = useState({
     image: false,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -149,6 +149,7 @@
       "url": "Enter URL",
       "enterText": "Enter text",
       "writeSomething": "Write something …",
+      "writeSlashForCommands": "Write '/' for commands...",
       "searchLanguages": "Search languages"
     },
     "table": {


### PR DESCRIPTION
- Ref: https://github.com/neetozone/neeto-kb-web/issues/8482

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
